### PR TITLE
[FEATURE] Watch only useful events

### DIFF
--- a/lib/docker-sync/watch_strategy/fswatch.rb
+++ b/lib/docker-sync/watch_strategy/fswatch.rb
@@ -15,7 +15,7 @@ module Docker_Sync
       def initialize(sync_name, options)
         @sync_name = sync_name
         @options = options
-        @events_to_watch = %w(AttributeModified Created Removed Updated)
+        @events_to_watch = %w(AttributeModified Created Link MovedFrom MovedTo Renamed Removed Updated)
 
         begin
           Preconditions::fswatch_available

--- a/lib/docker-sync/watch_strategy/fswatch.rb
+++ b/lib/docker-sync/watch_strategy/fswatch.rb
@@ -15,6 +15,7 @@ module Docker_Sync
       def initialize(sync_name, options)
         @sync_name = sync_name
         @options = options
+        @events_to_watch = %w(AttributeModified Created Removed Updated)
 
         begin
           Preconditions::fswatch_available
@@ -50,6 +51,7 @@ module Docker_Sync
           args = @options['watch_excludes'].map { |pattern| "--exclude='#{pattern}'" } + args
         end
         args.push('-orIE')
+        args.push(@events_to_watch.map { |pattern| "--event #{pattern}" })
         args.push(@options['watch_args']) if @options.key?('watch_args')
         args.push(@options['src'])
 


### PR DESCRIPTION
Even with the `-o` parameter, I found that the watch triggers far more than needed.

This patch limits the events that should be listened by `fsevents` , see http://emcrisostomo.github.io/fswatch/doc/1.9.2/fswatch.html/Invoking-fswatch.html#Filtering-by-Event-Type for a complete list of events. 