### PR TITLE
Strategy unison-dualside with container events

### DIFF
--- a/example/create-data/Dockerfile
+++ b/example/create-data/Dockerfile
@@ -1,0 +1,6 @@
+FROM alpine
+
+ADD ./entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/example/create-data/entrypoint.sh
+++ b/example/create-data/entrypoint.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+echo "$1" > /command.txt
+
+if [ "$1" == "watch" ]; then
+    adduser -u $(stat -c '%u' /data) -D www-data
+
+    while true; do
+        su www-data -c 'date >> /data/filefromcontainer.txt';
+        sleep 5;
+    done
+fi
+
+
+
+exec "$@"

--- a/example/data3/filefromhost.txt
+++ b/example/data3/filefromhost.txt
@@ -1,0 +1,1 @@
+File from host

--- a/example/docker-compose-dev.yml
+++ b/example/docker-compose-dev.yml
@@ -9,9 +9,14 @@ services:
   otherapp:
     volumes_from:
       - container:simpleexample-sync:rw # will be mounted on /app/code
+  appthatproducedata:
+    volumes_from:
+      - container:unison-dualside-sync:rw # will be mounted on /data
 
 volumes:
   fullexample-sync:
     external: true
   simpleexample-sync:
+    external: true
+  unison-dualside-sync:
     external: true

--- a/example/docker-compose.yml
+++ b/example/docker-compose.yml
@@ -10,3 +10,7 @@ services:
     image: alpine
     container_name: 'simpleexample_app'
     command: ['watch', '-n1', 'cat /app/code/somefile.txt']
+  appthatproducedata:
+    build: ./create-data
+    container_name: 'unison-dualside_app'
+    command: ['watch', '-n1', 'cat /data/filefromhost.txt']

--- a/example/docker-sync.yml
+++ b/example/docker-sync.yml
@@ -38,6 +38,7 @@ syncs:
     sync_user: 'test'
     # this does not user groupmap but rather configures the server to map
     # optional: usually if you map users you want to set the user id of your application container here
+    # set it to 'from_host' to automatically bound it to the uid of the user who launches docker-sync (unison only at the moment)
     sync_userid: '5000'
     # optional, use this to map the files to a specific group on sync. Helps fixing permissions, You can use names and guids
     sync_group: 'testgroup'
@@ -45,6 +46,14 @@ syncs:
     # this does not user groupmap but rather configures the server to map
     sync_groupid: '6000'
 
+    # required for strategy unison-dualside.
+    # Specify the host IP in the docker or public network or set it to 'auto' to try to guess it automatically
+    unison-dualside_host_ip: 'auto'
+    # required for unison-dualside, specify the port of the unison server that runs directly on the host
+    unison-dualside_host_server_port: 6000
+
+    # optional: enable fswatch in the container side (unison only) to automatically retrieve files created in the container to the host
+    watch_in_container: true
     watch_excludes: ['.*/.git', '.*/node_modules', '.*/bower_components', '.*/sass-cache', '.*/.sass-cache', '.*/.sass-cache', '.coffee', '.scss', '.sass', '.gitignore']
     # optional: use this to switch to fswatch verbose mode
     watch_args: '-v'
@@ -56,3 +65,13 @@ syncs:
     sync_host_ip: 'localhost'
     sync_host_port: 20872
     sync_strategy: 'unison' # this time we pick unison
+  unison-dualside-sync:
+    src: './data3/'
+    dest: '/data'
+    image: 'mickaelperrin/docker-unison-fsevents'
+    sync_host_ip: '172.16.210.131'
+    sync_host_port: 20873
+    sync_userid: 'from_host'
+    unison-dualside_host_ip: 'auto'
+    unison-dualside_host_server_port: 6000
+    sync_strategy: 'unison-dualside'

--- a/lib/docker-sync/sync_process.rb
+++ b/lib/docker-sync/sync_process.rb
@@ -2,6 +2,7 @@ require 'thor/shell'
 # noinspection RubyResolve
 require 'docker-sync/sync_strategy/rsync'
 require 'docker-sync/sync_strategy/unison'
+require 'docker-sync/sync_strategy/unison-dualside'
 # noinspection RubyResolve
 require 'docker-sync/watch_strategy/fswatch'
 require 'docker-sync/watch_strategy/dummy'
@@ -36,6 +37,8 @@ module Docker_Sync
             @sync_strategy = Docker_Sync::SyncStrategy::Rsync.new(@sync_name, @options)
           when 'unison'
             @sync_strategy = Docker_Sync::SyncStrategy::Unison.new(@sync_name, @options)
+          when 'unison-dualside'
+            @sync_strategy = Docker_Sync::SyncStrategy::Unison_DualSide.new(@sync_name, @options)
           else
             @sync_strategy = Docker_Sync::SyncStrategy::Rsync.new(@sync_name, @options)
         end

--- a/lib/docker-sync/sync_strategy/unison-dualside.rb
+++ b/lib/docker-sync/sync_strategy/unison-dualside.rb
@@ -1,0 +1,199 @@
+require 'thor/shell'
+require 'docker-sync/preconditions'
+require 'open3'
+require 'socket'
+
+module Docker_Sync
+  module SyncStrategy
+    class Unison_DualSide
+      include Thor::Shell
+
+      @options
+      @sync_name
+      @watch_thread
+      @local_server_pid
+      UNISON_CONTAINER_PORT = '5000'
+      def initialize(sync_name, options)
+        @sync_name = sync_name
+        @options = options
+        # if a custom image is set, apply it
+        if @options.key?('image')
+          @docker_image = @options['image']
+        else
+          @docker_image = 'eugenmayer/unison'
+        end
+        begin
+          Preconditions::unison_available
+        rescue Exception => e
+          say_status 'error', "#{@sync_name} has been configured to sync with unison, but no unison available", :red
+          say_status 'error', e.message, :red
+          exit 1
+        end
+      end
+
+      def run
+        start_container
+        start_local_server
+        sync
+      end
+
+      def sync
+        args = sync_options
+        cmd = 'unison ' + args.join(' ')
+
+        say_status 'command', cmd, :white if @options['verbose']
+
+        stdout, stderr, exit_status = Open3.capture3(cmd)
+        if not exit_status.success?
+          say_status 'error', "Error starting sync, exit code #{$?.exitstatus}", :red
+          say_status 'message', stderr
+        else
+          say_status 'ok', "Synced #{@options['src']}", :white
+          if @options['verbose']
+            say_status 'output', stdout
+          end
+        end
+      end
+
+      def sync_options
+        args = []
+
+        unless @options['sync_excludes'].nil?
+          args = @options['sync_excludes'].map { |pattern| "-ignore='Path #{pattern}'" } + args
+        end
+        args.push(@options['src'])
+        args.push('-auto')
+        args.push('-batch')
+        args.push('-owner') if @options['sync_userid'] == 'from_host'
+        args.push('-numericids') if @options['sync_userid'] == 'from_host'
+        args.push(@options['sync_args']) if @options.key?('sync_args')
+        args.push("socket://#{@options['sync_host_ip']}:#{@options['sync_host_port']}/")
+        #args.push('-debug verbose') if @options['verbose']
+        if @options.key?('sync_user') || @options.key?('sync_group') || @options.key?('sync_groupid')
+          raise('Unison does not support sync_user, sync_group, sync_groupid - please use rsync if you need that')
+        end
+        if  @options.key?('sync_userid') && @options['sync_userid'] != 'from_host'
+          raise('Unison does not support sync_userid with a parameter different than \'from_host\'')
+        end
+        return args
+      end
+
+      def start_container
+        say_status 'ok', 'Starting unison', :white
+        container_name = get_container_name
+        volume_name = get_volume_name
+        env = {}
+
+        env['ENABLE_WATCH'] = 'true'
+        # Excludes for fswatch and unison uses the same value both in the host and in the container
+        env['FSWATCH_EXCLUDES'] = @options['watch_excludes'].map { |pattern| "--exclude='#{pattern}'" }.join(' ') if @options.key?('watch_excludes')
+        env['UNISON_EXCLUDES'] = @options['sync_excludes'].map { |pattern| "-ignore='Path #{pattern}'" }.join(' ') if @options.key?('sync_excludes')
+        # Specify the IP of the host to call the host unison server from the container
+        env['HOST_IP'] = get_host_ip
+        env['UNISON_HOST_PORT'] = @options['unison-dualside_host_server_port']
+
+        if @options['sync_userid'] == 'from_host'
+          env['UNISON_DIR_OWNER'] = Process.uid
+        end
+
+        additional_docker_env = env.map{ |key,value| "-e #{key}=\"#{value}\"" }.join(' ')
+        running = `docker ps --filter 'status=running' --filter 'name=#{container_name}' | grep #{container_name}`
+        if running == ''
+          say_status 'ok', "#{container_name} container not running", :white if @options['verbose']
+          exists = `docker ps --filter "status=exited" --filter "name=#{container_name}" | grep #{container_name}`
+          if exists == ''
+            say_status 'ok', "creating #{container_name} container", :white if @options['verbose']
+            cmd = "docker run -p '#{@options['sync_host_port']}:#{UNISON_CONTAINER_PORT}' \
+                              -v #{volume_name}:#{@options['dest']} \
+                              -e UNISON_DIR=#{@options['dest']} \
+                              #{additional_docker_env} \
+                              --name #{container_name} \
+                              -d #{@docker_image}"
+          else
+            say_status 'ok', "starting #{container_name} container", :white if @options['verbose']
+            cmd = "docker start #{container_name}"
+          end
+          say_status 'command', cmd, :white if @options['verbose']
+          `#{cmd}` || raise('Start failed')
+        else
+          say_status 'ok', "#{container_name} container still running", :blue
+        end
+        say_status 'ok', "starting initial #{container_name} of src", :white if @options['verbose']
+        # this sleep is needed since the container could be not started
+        sleep 5 # TODO: replace with unison -testserver
+        sync
+        say_status 'success', 'Unison server started', :green
+      end
+
+      # Start an unison server on the host
+      def start_local_server
+        say_status 'ok', 'Starting local unison server', :white
+
+        if not @options.key?('unison-dualside_host_server_port')
+          raise('Missing unison-dualside_host_server_port option. In order to get files synced back automatically from the
+          container, you must specify the port of the local unison server.')
+        end
+        cmd = "unison -socket #{@options['unison-dualside_host_server_port']}"
+        say_status 'command', cmd, :white if @options['verbose']
+
+        # Store the pid of the local unison server, to kill it when docker-sync stops
+        @local_server_pid = Process.fork do
+          # Run the local unison server in the source folder
+          Dir.chdir(@options['src']){
+            `#{cmd}` || raise('Start of local unison server failed')
+          }
+        end
+      end
+
+      # Try to guess the IP of the host to call the unison server from the container
+      # Or use the value specified in the config option
+      def get_host_ip
+        if @options['unison-dualside_host_ip'] != 'auto' && @options.key?('unison-dualside_host_ip')
+          host_ip = @options['host_ip']
+        elsif @options['unison-dualside_host_ip'] == 'auto' || (not @options.key?('unison-dualside_host_ip'))
+          host_ip = Socket.ip_address_list.find { |ai| ai.ipv4? && !ai.ipv4_loopback? }.ip_address
+        end
+        return host_ip
+      end
+
+      # Kill the local unison server
+      def stop_local_server
+        Process.kill "TERM", @local_server_pid
+        Process.wait @local_server_pid
+      end
+
+      def get_container_name
+        return "#{@sync_name}"
+      end
+
+      def get_volume_name
+        return @sync_name
+      end
+
+      def stop_container
+        `docker stop #{get_container_name}`
+      end
+
+      def reset_container
+        stop_container
+        `docker rm #{get_container_name}`
+        `docker volume rm #{get_volume_name}`
+      end
+
+      def clean
+        reset_container
+      end
+
+      def stop
+        say_status 'ok', "Stopping sync container #{get_container_name}"
+        begin
+          stop_container
+          stop_local_server
+        rescue Exception => e
+          say_status 'error', "Stopping failed of #{get_container_name}:", :red
+          puts e.message
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This is a rewrite of the PR #47 that adds the ability to get files created in the container back to the host immediately without having to wait that a new file is modified on the host side to perform a new sync.

It's intended to work with the PR https://github.com/EugenMayer/docker-unison/pull/3/files.

This PR implements : 
- the feature as a new sync strategy
- an example

