### PR TITLE
[FEATURE] Start / wtop watch from sync_manager

### DIFF
--- a/lib/docker-sync/sync_manager.rb
+++ b/lib/docker-sync/sync_manager.rb
@@ -150,5 +150,17 @@ module Docker_Rsync
         end
       }
     end
+
+    def watch_stop
+      @sync_processes.each { |sync_process|
+        sync_process.watch_thread.kill unless sync_process.watch_thread.nil?
+      }
+    end
+
+    def watch_start
+      @sync_processes.each { |sync_process|
+        sync_process.watch
+      }
+    end
   end
 end


### PR DESCRIPTION
This PR adds the ability to easily start stop watchers from the sync_manager. This is really helpful while bootstrapping a large project, and use in scripting like : 

    #!/usr/bin/env ruby
    require 'docker-sync/sync_manager'
    require 'docker-sync/config'
    require 'docker-sync/preconditions'
    require 'docker-sync/update_check'

    config_path = File.expand_path('./src/docker/docker-sync.yml', File.dirname(__FILE__))
    @sync_manager = Docker_Rsync::SyncManager.new(:config_path => config_path)
    @sync_manager.run() # do not call .join_threads now
    @sync_manager.watch_stop()

    system('./install.sh')
    @sync_manager.sync()
    @sync_manager.watch_start()
    ### debootsrapping
    begin
      @sync_manager.join_threads
    rescue SystemExit, Interrupt
      say_status 'shutdown', 'Shutting down...', :blue

      @sync_manager.stop
    rescue Exception => e

      puts "EXCEPTION: #{e.inspect}"
      puts "MESSAGE: #{e.message}"

    end
