### PR TITLE
[TASK] Reduce unison verbosity and enable for dual

### DIFF
--- a/lib/docker-sync/sync_strategy/unison-dualside.rb
+++ b/lib/docker-sync/sync_strategy/unison-dualside.rb
@@ -68,7 +68,7 @@ module Docker_Sync
         args.push('-numericids') if @options['sync_userid'] == 'from_host'
         args.push(@options['sync_args']) if @options.key?('sync_args')
         args.push("socket://#{@options['sync_host_ip']}:#{@options['sync_host_port']}/")
-        #args.push('-debug verbose') if @options['verbose']
+        args.push('-debug all') if @options['verbose']
         if @options.key?('sync_user') || @options.key?('sync_group') || @options.key?('sync_groupid')
           raise('Unison does not support sync_user, sync_group, sync_groupid - please use rsync if you need that')
         end

--- a/lib/docker-sync/sync_strategy/unison.rb
+++ b/lib/docker-sync/sync_strategy/unison.rb
@@ -63,7 +63,7 @@ module Docker_Sync
         args.push('-batch')
         args.push(@options['sync_args']) if @options.key?('sync_args')
         args.push("socket://#{@options['sync_host_ip']}:#{@options['sync_host_port']}/")
-        args.push('-debug verbose') if @options['verbose']
+        args.push('-debug all') if @options['verbose']
         if @options.key?('sync_user') || @options.key?('sync_group') || @options.key?('sync_groupid') || @options.key?('sync_userid')
           raise('Unison does not support sync_user, sync_group, sync_groupid or sync_userid - please use rsync if you need that')
         end


### PR DESCRIPTION
`verbose` option for unison seems to be far too heavy for common debugging use, using `all` should be sufficient.

This PR fixes also a bug with `unison-dualside` where the unison verbosity was commented