### PR TITLE
[FEATURE] Add project-name like -p option of docker-compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,3 +4,6 @@ Anything under [http://docker-sync.io](http://docker-sync.io)
 
 [Please help adding what you need](https://github.com/EugenMayer/docker-sync/wiki#development), do not spawn [another project](https://github.com/EugenMayer/docker-sync/wiki/Alternatives-to-docker-sync), just because e.g. you need NFS. Either help out in one of the others, all try to unite all the different technologies in docker-sync by adding a [strategy](https://github.com/EugenMayer/docker-sync/wiki/6.-Development#general-layout).
 
+
+
+[![Join the chat at https://gitter.im/EugenMayer/docker-sync](https://badges.gitter.im/EugenMayer/docker-sync.svg)](https://gitter.im/EugenMayer/docker-sync?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)

--- a/docker_sync.iml
+++ b/docker_sync.iml
@@ -6,7 +6,7 @@
     <orderEntry type="jdk" jdkName="rbenv: 2.2.4" jdkType="RUBY_SDK" />
     <orderEntry type="sourceFolder" forTests="false" />
     <orderEntry type="library" scope="PROVIDED" name="backticks (v0.5.0, rbenv: 2.2.4) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="bundler (v1.11.2, rbenv: 2.2.4) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="bundler (v1.12.1, rbenv: 2.2.4) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="docker-compose (v0.8.3, rbenv: 2.2.4) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="gem_update_checker (v0.2.0, rbenv: 2.2.4) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="thor (v0.19.1, rbenv: 2.2.4) [gem]" level="application" />

--- a/example/docker-sync.yml
+++ b/example/docker-sync.yml
@@ -13,6 +13,8 @@ options:
   # ADVANVED: default:eugenmayer/unison -  the image to use for the unison container. Do not change this until you exactly know, what you are doing
   # you cannot just use "some unison" container, you entrypoint needs features, check the Dockerfiles
   unison_image: 'eugenmayer/unison'
+  # You can specify a project name (like the -p option of docker-compose). This will prefix all volume container names with it.
+  project: 'project_name'
 syncs:
   # IMPORTANT: this name must be unique and should NOT match your real application container name!
   fullexample-sync:

--- a/example/docker-sync.yml
+++ b/example/docker-sync.yml
@@ -14,6 +14,7 @@ options:
   # you cannot just use "some unison" container, you entrypoint needs features, check the Dockerfiles
   unison_image: 'eugenmayer/unison'
   # You can specify a project name (like the -p option of docker-compose). This will prefix all volume container names with it.
+  # If you set the value 'auto', the project name will be determined from the folder name that contains this file.
   project: 'project_name'
 syncs:
   # IMPORTANT: this name must be unique and should NOT match your real application container name!

--- a/lib/docker-sync/sync_manager.rb
+++ b/lib/docker-sync/sync_manager.rb
@@ -55,6 +55,14 @@ module Docker_Rsync
           end
         end
 
+        # set the global project setting, if the sync-endpoint does not define a own one
+        unless config.key?('project')
+          @config_syncs[name]['project'] = ''
+          if @config_options.key?('project')
+            @config_syncs[name]['project'] = @config_options['project']
+          end
+        end
+
         # for each strategy check if a custom image has been defined and inject that into the sync-endpoints
         # which do fit for this strategy
         %w(rsync unison).each do |strategy|

--- a/lib/docker-sync/sync_manager.rb
+++ b/lib/docker-sync/sync_manager.rb
@@ -59,7 +59,7 @@ module Docker_Rsync
         unless config.key?('project')
           @config_syncs[name]['project'] = ''
           if @config_options.key?('project')
-            @config_syncs[name]['project'] = sanitize_project_name(@config_options['project'])
+            @config_syncs[name]['project'] = set_project_name(@config_options['project'])
           end
         end
 
@@ -70,6 +70,14 @@ module Docker_Rsync
             @config_syncs[name]['image'] = config["#{strategy}_image"]
           end
         end
+      end
+    end
+
+    def set_project_name(project_name)
+      if project_name == 'auto'
+        sanitize_project_name(File.basename(File.dirname(@config_path)))
+      else
+        sanitize_project_name(project_name)
       end
     end
 

--- a/lib/docker-sync/sync_manager.rb
+++ b/lib/docker-sync/sync_manager.rb
@@ -59,7 +59,7 @@ module Docker_Rsync
         unless config.key?('project')
           @config_syncs[name]['project'] = ''
           if @config_options.key?('project')
-            @config_syncs[name]['project'] = @config_options['project']
+            @config_syncs[name]['project'] = sanitize_project_name(@config_options['project'])
           end
         end
 
@@ -71,6 +71,10 @@ module Docker_Rsync
           end
         end
       end
+    end
+
+    def sanitize_project_name(project_name)
+      project_name.gsub(/[^a-zA-Z0-9]/, '')
     end
 
     def validate_config(config)

--- a/lib/docker-sync/sync_strategy/rsync.rb
+++ b/lib/docker-sync/sync_strategy/rsync.rb
@@ -11,8 +11,8 @@ module Docker_Sync
       @watch_thread
 
       def initialize(sync_name, options)
-        @sync_name = sync_name
         @options = options
+        @sync_name = @options['project'] != '' ? @options['project'] + '_' + sync_name : sync_name
         # if a custom image is set, apply it
         if @options.key?('image')
           @docker_image = @options['image']

--- a/lib/docker-sync/sync_strategy/unison-dualside.rb
+++ b/lib/docker-sync/sync_strategy/unison-dualside.rb
@@ -14,8 +14,8 @@ module Docker_Sync
       @local_server_pid
       UNISON_CONTAINER_PORT = '5000'
       def initialize(sync_name, options)
-        @sync_name = sync_name
         @options = options
+        @sync_name = @options['project'] != '' ? @options['project'] + '_' + sync_name : sync_name
         # if a custom image is set, apply it
         if @options.key?('image')
           @docker_image = @options['image']

--- a/lib/docker-sync/sync_strategy/unison.rb
+++ b/lib/docker-sync/sync_strategy/unison.rb
@@ -12,8 +12,8 @@ module Docker_Sync
       @watch_thread
       UNISON_CONTAINER_PORT = '5000'
       def initialize(sync_name, options)
-        @sync_name = sync_name
         @options = options
+        @sync_name = @options['project'] != '' ? @options['project'] + '_' + sync_name : sync_name
         # if a custom image is set, apply it
         if @options.key?('image')
           @docker_image = @options['image']

--- a/lib/docker-sync/watch_strategy/fswatch.rb
+++ b/lib/docker-sync/watch_strategy/fswatch.rb
@@ -1,6 +1,7 @@
 require 'thor/shell'
 require 'docker-sync/execution'
 require 'docker-sync/preconditions'
+require 'pathname'
 
 module Docker_Sync
   module WatchStrategy
@@ -56,13 +57,11 @@ module Docker_Sync
         args.push(@options['src'])
 
         sync_command = 'thor sync:sync'
-        begin
-          Preconditions::docker_sync_available
+        exec_name =File.basename($PROGRAM_NAME)
+        if exec_name != 'thor'
           sync_command = 'docker-sync sync'
-        rescue Exception => e
-          say_status 'warning', 'docker-sync not available, assuming dev mode, using thor', :yellow
-          puts e.message
-          sync_command = 'thor sync:sync'
+        else
+          say_status 'warning', 'Called user thor, not docker-sync* wise, assuming dev mode, using thor', :yellow
         end
         args.push(" | xargs -I -n1 #{sync_command} -n #{@sync_name} --config='#{@options['config_path']}'")
       end


### PR DESCRIPTION
This PR mimics the `-p` option of `docker-compose` by setting a global option `project`.

If set, the `project` value will be append to the container name with an additionnal '_'.

The project name is sanitized by removing all non standard characters.

The special value `auto` determines the project name from the folder name where the docker-sync.yml file is stored.