### PR TITLE
[BUGFIX #87] Container may fails to start

### DIFF
--- a/lib/docker-sync/sync_strategy/rsync.rb
+++ b/lib/docker-sync/sync_strategy/rsync.rb
@@ -87,10 +87,10 @@ module Docker_Sync
         say_status 'ok', 'Starting rsync', :white
         container_name = get_container_name
         volume_name = get_volume_name
-        running = `docker ps --filter 'status=running' --filter 'name=#{container_name}' | grep #{container_name}`
+        running = `docker ps --filter 'status=running' --filter 'name=#{container_name}' | sed -E -n 's/.*\\s(.*)$/\\1/p' | grep '^#{container_name}$'`
         if running == '' # container is yet not running
           say_status 'ok', "#{container_name} container not running", :white if @options['verbose']
-          exists = `docker ps --filter "status=exited" --filter "name=#{container_name}" | grep #{container_name}`
+          exists = `docker ps --filter "status=exited" --filter "name=#{container_name}" | sed -E -n 's/.*\\s(.*)$/\\1/p' | grep '^#{container_name}$'`
           if exists == '' # container has yet not been created
             say_status 'ok', "creating #{container_name} container", :white if @options['verbose']
 

--- a/lib/docker-sync/sync_strategy/unison-onesided.rb
+++ b/lib/docker-sync/sync_strategy/unison-onesided.rb
@@ -78,11 +78,10 @@ module Docker_Sync
         say_status 'ok', 'Starting unison', :white
         container_name = get_container_name
         volume_name = get_volume_name
-
-        running = `docker ps --filter 'status=running' --filter 'name=#{container_name}' | grep #{container_name}`
+        running = `docker ps --filter 'status=running' --filter 'name=#{container_name}' | sed -E -n 's/.*\\s(.*)$/\\1/p' | grep '^#{container_name}$'`
         if running == ''
           say_status 'ok', "#{container_name} container not running", :white if @options['verbose']
-          exists = `docker ps --filter "status=exited" --filter "name=#{container_name}" | grep #{container_name}`
+          exists = `docker ps --filter "status=exited" --filter "name=#{container_name}" | sed -E -n 's/.*\\s(.*)$/\\1/p' | grep '^#{container_name}$'`
           if exists == ''
             say_status 'ok', "creating #{container_name} container", :white if @options['verbose']
             cmd = "docker run -p '#{@options['sync_host_port']}:#{UNISON_CONTAINER_PORT}' -v #{volume_name}:#{@options['dest']} -e UNISON_DIR=#{@options['dest']} --name #{container_name} -d #{@docker_image}"

--- a/lib/docker-sync/sync_strategy/unison.rb
+++ b/lib/docker-sync/sync_strategy/unison.rb
@@ -125,10 +125,10 @@ module Docker_Sync
         end
 
         additional_docker_env = env.map{ |key,value| "-e #{key}=\"#{value}\"" }.join(' ')
-        running = `docker ps --filter 'status=running' --filter 'name=#{container_name}' | grep #{container_name}`
+        running = `docker ps --filter 'status=running' --filter 'name=#{container_name}' | sed -E -n 's/.*\\s(.*)$/\\1/p' | grep '^#{container_name}$'`
         if running == ''
           say_status 'ok', "#{container_name} container not running", :white if @options['verbose']
-          exists = `docker ps --filter "status=exited" --filter "name=#{container_name}" | grep #{container_name}`
+          exists = `docker ps --filter "status=exited" --filter "name=#{container_name}" | sed -E -n 's/.*\\s(.*)$/\\1/p' | grep '^#{container_name}$'`
           if exists == ''
             say_status 'ok', "creating #{container_name} container", :white if @options['verbose']
             run_privileged = '--privileged' if @options.key?('max_inotify_watches') #TODO: replace by the minimum capabilities required


### PR DESCRIPTION
- PB: depending on their name some container may fails to start. This
comes from the way to test if a container exists / is already running.
- FIX: extract the container name from the docker inspect command
and sed and ensure it matches with grep on full string