### PR TITLE
[BUGFIX] osx vanilla sed doesn't support the -r option

### DIFF
--- a/lib/docker-sync/sync_strategy/unison.rb
+++ b/lib/docker-sync/sync_strategy/unison.rb
@@ -158,7 +158,7 @@ module Docker_Sync
       end
 
       def get_host_port(container_name, container_port)
-        cmd = 'docker inspect --format=" {{ .NetworkSettings.Ports }} " ' + container_name + ' | sed -r "s/.*map\[' + container_port + '[^ ]+\s([0-9]+).*/\1/"'
+        cmd = 'docker inspect --format=" {{ .NetworkSettings.Ports }} " ' + container_name + ' | sed "s/.*map\[' + container_port + '[^ ]\+\s\([0-9]\+\).*/\1/"'
         say_status 'command', cmd, :white if @options['verbose']
         stdout, stderr, exit_status = Open3.capture3(cmd)
         if not exit_status.success?


### PR DESCRIPTION
- PB: on some systems sed doesn't support the exended syntax.
- FIX: rewrite the regexp without the use of the extended syntax