### PR TITLE
[BUGFIX] Missing unox requirement

### DIFF
--- a/lib/docker-sync/preconditions.rb
+++ b/lib/docker-sync/preconditions.rb
@@ -47,7 +47,8 @@ module Preconditions
   def self.unox_available
     if (find_executable0 'unison-fsmonitor').nil?
       cmd = 'curl "https://raw.githubusercontent.com/hnsl/unox/master/unox.py" -o "/usr/local/bin/unison-fsmonitor" \
-      && chmod +x /usr/local/bin/unison-fsmonitor'
+      && chmod +x /usr/local/bin/unison-fsmonitor \
+      && easy_install pip && pip install macfsevents'
       Thor::Shell::Basic.new.say_status 'warning', "Could not find unison-fsmonitor binary in path. Please install unox before you continue, see https://github.com/hnsl/unox.", :yellow
       if Thor::Shell::Basic.new.yes?("Shall I install unison-fsmonitor for you?")
         `#{cmd}`


### PR DESCRIPTION
- PB: unox depends on the macfsevents python library.
- FIX: install using easy install and pip

We use also pip rather thant easy install as we got some troubles:
https://files.gitter.im/EugenMayer/docker-sync/HX1J/blob