### PR TITLE
Specify gemspec in Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,8 +1,3 @@
 source 'https://rubygems.org'
-gem 'thor'
-# compose is a dynamic dependency, if someone is not using stack, he will not need it.
-# otherwise installed on demand
-gem 'docker-compose', '0.8.3'
-gem 'gem_update_checker'
-gem 'terminal-notifier', '1.6.3'
-#ruby '>= 2.0' not possible
+
+gemspec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,12 @@
+PATH
+  remote: .
+  specs:
+    docker-sync (0.1.1)
+      docker-compose (= 0.8.3)
+      gem_update_checker (~> 0.2.0, >= 0.2.0)
+      terminal-notifier (= 1.6.3)
+      thor (~> 0.19, >= 0.19.0)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -12,10 +21,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  docker-compose (= 0.8.3)
-  gem_update_checker
-  terminal-notifier (= 1.6.3)
-  thor
+  docker-sync!
 
 BUNDLED WITH
-   1.12.1
+   1.12.5


### PR DESCRIPTION
Bundler can read dependencies directly from the .gemspec, which reduces
duplication and potential dependency masking problems