### PR TITLE
[TASK] Unison: fix & improve documentation example

### DIFF
--- a/example/docker-sync.yml
+++ b/example/docker-sync.yml
@@ -65,13 +65,29 @@ syncs:
     sync_host_port: 20872
     sync_strategy: 'unison-onesided' # this time we pick unison-onesided
   unison-sync:
+      # unison strategy differs from unison-onsesided as:
+      # - it implements a native unison watcher through unox which allow granular syncing instead of full sync
+      # - it reacts from changes made also on the container side (and on the host of course)
+      sync_strategy: 'unison'
+      # common options
+      # see rsync documentation for all these common options
       src: './data4/'
       dest: '/data'
-      image: 'mickaelperrin/docker-unison-unox'
+      notify_terminal: true
       sync_host_ip: 'localhost'
-      sync_strategy: 'unison'
       sync_user: 'www-data'
       sync_userid: '33'
+      # Additional unison options
+      # @see http://www.cis.upenn.edu/~bcpierce/unison/download/releases/stable/unison-manual.html#prefs
+      # For example, these provided options will automatically resolve conflicts by using the newer version of the file
+      # and append a suffix to the conflicted file to prevent its deletion.
+      sync_args: [ '-prefer newer', '-copyonconflict' ]
+      # Exclude some files / directories that matches **exactly** the path
+      # this currently use the the -Path option of unison, additionnal ways to exclude are available
+      # @see http://www.cis.upenn.edu/~bcpierce/unison/download/releases/stable/unison-manual.html#pathspec
+      # use them in sync_args if you need a specific exclude, for example: sync_args = [ "-ignore='Regex sites/.*\.dev'" ]
+      sync_excludes: [ '.git', '.idea', 'node_modules' ]
+      # specific options
       # If you need to sync a lot of files, you can reach out the system limit
       # of inotify watches. You can set the limit by using this parameter. This will
       # prompt you for your sudo password to modify the system configuration.


### PR DESCRIPTION
Documented:
- how unison differs from unison-onesided,
- `sync_args`with example with `-prefer newer -copyonconflict` and link to unison documentation about parameters
- `sync_excludes` with alert that it must match **exactly** the path from root and link to unison documentation about unison path and excludes

Fix:
- removed image mickaelperrin/unison:unox