### PR TITLE
Support configuring rsync allowed hosts and copying symlinks

### DIFF
--- a/docker-sync.gemspec
+++ b/docker-sync.gemspec
@@ -12,6 +12,6 @@ Gem::Specification.new do |s|
   s.required_ruby_version = '>= 2.0'
   s.add_runtime_dependency 'thor', '~> 0.19', '>= 0.19.0'
   s.add_runtime_dependency 'gem_update_checker', '~> 0.2.0', '>= 0.2.0'
-  s.add_runtime_dependency 'docker-compose', '0.8.3'
+  s.add_runtime_dependency 'docker-compose', '0.8.4'
   s.add_runtime_dependency 'terminal-notifier', '1.6.3'
 end


### PR DESCRIPTION
These features were needed for us to get docker-sync working in our environment.

Added the option `rsync_allowed_cidr` where you can specify a string of CIDRs rsync allows to sync with, e.g. ours looks like:

```yaml
....
syncs:
  foo-sync:
    ...
    rsync_allowed_cidr: '10.10.10.0/24 192.168.0.0/16 172.16.0.0/12'
    copy_symlinks: 'true'
...
```

This PR also adds the option `copy_symlinks` which adds the `-L` option when syncing code into the container. We were running into a permissions issue when trying to copy the symlink directly into the container.