### PR TITLE
configuration to pass --build flag to `docker-compose up`

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     docker-sync (0.1.2)
-      docker-compose (= 0.8.3)
+      docker-compose (= 1.0.0)
       gem_update_checker (~> 0.2.0, >= 0.2.0)
       terminal-notifier (= 1.6.3)
       thor (~> 0.19, >= 0.19.0)
@@ -10,9 +10,9 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    backticks (0.5.0)
-    docker-compose (0.8.3)
-      backticks (~> 0.5)
+    backticks (1.0.0)
+    docker-compose (1.0.0)
+      backticks (~> 1.0)
     gem_update_checker (0.2.0)
     terminal-notifier (1.6.3)
     thor (0.19.1)
@@ -24,4 +24,4 @@ DEPENDENCIES
   docker-sync!
 
 BUNDLED WITH
-   1.12.5
+   1.13.1

--- a/docker-sync.gemspec
+++ b/docker-sync.gemspec
@@ -12,6 +12,6 @@ Gem::Specification.new do |s|
   s.required_ruby_version = '>= 2.0'
   s.add_runtime_dependency 'thor', '~> 0.19', '>= 0.19.0'
   s.add_runtime_dependency 'gem_update_checker', '~> 0.2.0', '>= 0.2.0'
-  s.add_runtime_dependency 'docker-compose', '0.8.3'
+  s.add_runtime_dependency 'docker-compose', '1.0.0'
   s.add_runtime_dependency 'terminal-notifier', '1.6.3'
 end

--- a/lib/docker-sync/compose.rb
+++ b/lib/docker-sync/compose.rb
@@ -42,7 +42,11 @@ class ComposeManager
 
   def run
     say_status 'ok','starting compose',:green
-    @compose_session.up(build: @global_options['compose-force-build'])
+    options = Hash.new
+    if @global_options['compose-force-build']
+      options['build'] = true
+    end
+    @compose_session.up(options)
   end
 
   def stop

--- a/lib/docker-sync/compose.rb
+++ b/lib/docker-sync/compose.rb
@@ -42,7 +42,7 @@ class ComposeManager
 
   def run
     say_status 'ok','starting compose',:green
-    @compose_session.up
+    @compose_session.up(build: @global_options['compose-force-build'])
   end
 
   def stop


### PR DESCRIPTION
Thanks for all your work on docker-sync! It's been really useful in speeding up my local development process.

One thing I was missing from my purely `docker-compose` based process was being able to pass the `--build` flag to `docker-compose up` to ensure that any files not synced from my host into the container were up-to-date.

I just submitted [a change](https://github.com/xeger/docker-compose/pull/39) to the docker-compose gem to expose the `--build` flag, and I was hoping you'd consider adding a configuration for docker-sync to pass this flag. Currently that flag is called `compose-force-build` in the global options section, but I'd be happy to change it if you have any suggestions.