### PR TITLE
Don't hardcode the path for sed - e.g. sed is in /bin on most Linux systems

### DIFF
--- a/lib/docker-sync/sync_strategy/unison.rb
+++ b/lib/docker-sync/sync_strategy/unison.rb
@@ -173,7 +173,8 @@ module Docker_Sync
       end
 
       def get_host_port(container_name, container_port)
-        cmd = 'docker inspect --format=" {{ .NetworkSettings.Ports }} " ' + container_name + ' | sed  -E "s/.*map\[' + container_port + '[^ ]+ ([0-9]*)[^0-9].*/\1/"'
+        File.exist?('/usr/bin/sed') ? sed = '/usr/bin/sed' : sed = `which sed`.chomp # use macOS native sed in /usr/bin/sed first, fallback to sed in $PATH if it's not there
+        cmd = 'docker inspect --format=" {{ .NetworkSettings.Ports }} " ' + container_name + " | #{sed} " + '-E "s/.*map\[' + container_port + '[^ ]+ ([0-9]*)[^0-9].*/\1/"'
         say_status 'command', cmd, :white if @options['verbose']
         stdout, stderr, exit_status = Open3.capture3(cmd)
         if not exit_status.success?

--- a/lib/docker-sync/sync_strategy/unison.rb
+++ b/lib/docker-sync/sync_strategy/unison.rb
@@ -173,7 +173,7 @@ module Docker_Sync
       end
 
       def get_host_port(container_name, container_port)
-        cmd = 'docker inspect --format=" {{ .NetworkSettings.Ports }} " ' + container_name + ' | /usr/bin/sed  -E "s/.*map\[' + container_port + '[^ ]+ ([0-9]*)[^0-9].*/\1/"'
+        cmd = 'docker inspect --format=" {{ .NetworkSettings.Ports }} " ' + container_name + ' | sed  -E "s/.*map\[' + container_port + '[^ ]+ ([0-9]*)[^0-9].*/\1/"'
         say_status 'command', cmd, :white if @options['verbose']
         stdout, stderr, exit_status = Open3.capture3(cmd)
         if not exit_status.success?


### PR DESCRIPTION
I have to support a Docker dev environment where the developers use a mixture of macOS and Linux.  I use docker-sync with the unison sync strategy, because the performance of the dev environment using Docker for mac osxfs shares is terrible.  I also don't want to have to maintain two completely separate paths for macOS and Linux workstations, so I install and use docker-sync on both platforms.

It actually works very well on Linux, with very little fiddling required, as long as the unison deb/RPM includes the Linux native 'unison-fsmonitor'.  However, there is one little gotcha - the unison sync strategy hardcodes the path to sed as /usr/bin/sed, which isn't where it is located on Linux - it's in /bin/sed usually.

So, don't hardcode the path - let $PATH do its job.