### PR TITLE
remove rsync trailing slash in command args

### DIFF
--- a/example/docker-sync.yml
+++ b/example/docker-sync.yml
@@ -21,7 +21,7 @@ syncs:
     # enable terminal_notifier. On every sync sends a Terminal Notification regarding files being synced. ( Mac Only ).
     # good thing incase you are developing and want to know exactly when your changes took effect.
     notify_terminal: true
-    # which folder to watch / sync from - you can use tiled, it will get expanded. Be aware the then trailing slash makes a difference
+    # which folder to watch / sync from - you can use tilde, it will get expanded. Be aware the then trailing slash makes a difference
     # if you add them, only the inner parts of the folder gets synced, otherwise the parent folder will be synced as top-level folder
     src: './data1/'
     # which destination on the sync-container. Since you will use volumes_from to mount this, this should match your code-deployment location in the real container

--- a/lib/docker-sync/sync_strategy/rsync.rb
+++ b/lib/docker-sync/sync_strategy/rsync.rb
@@ -67,7 +67,7 @@ module Docker_Sync
         # in the config - see start_container
         #args.push("--usermap='*:#{@options['sync_user']}'") if @options.key?('sync_user')
         #args.push("--groupmap='*:#{@options['sync_group']}'") if @options.key?('sync_group')
-        args.push("#{@options['src']}/") # add a trailing slash
+        args.push("#{@options['src']}")
         args.push("rsync://#{@options['sync_host_ip']}:#{@options['sync_host_port']}/volume")
         return args
       end


### PR DESCRIPTION
Since the docker-sync.yml mentions the user has the option to add a
slash or not, we should not hardcode a trailing slash.

also fixed a typo in the yml (tilde)