### PR TITLE
Preserve forward slash in sync src after expanding path

### DIFF
--- a/lib/docker-sync/sync_manager.rb
+++ b/lib/docker-sync/sync_manager.rb
@@ -44,9 +44,14 @@ module Docker_sync
     def upgrade_syncs_config
       @config_syncs.each do |name, config|
         @config_syncs[name]['config_path'] = @config_path
-        # expand the sync source to remove ~ and similar expressions in the path
-        @config_syncs[name]['src'] = File.expand_path(@config_syncs[name]['src'], File.dirname(@config_path))
-        @config_syncs[name]['cli_mode'] = @config_global['cli_mode'] || 'auto'
+
+	# [nbr] convert the sync src from relative to absolute path
+	#	preserve '/' as it may be significant to the sync cmd
+        absolute_path = File.expand_path(@config_syncs[name]['src'])
+	absolute_path << "/" if @config_syncs[name]['src'].end_with?("/")
+	@config_syncs[name]['src'] = absolute_path
+
+	@config_syncs[name]['cli_mode'] = @config_global['cli_mode'] || 'auto'
 
         # set the global verbose setting, if the sync-endpoint does not define a own one
         unless config.key?('verbose')


### PR DESCRIPTION
#173 causes a regression which affects sync behavior in at least the rsync strategy.

The use of `/` in rsync is signficant, and results in different behaviors. Example:
```
$ tree
├── a
│   ├── 1
│   └── 2
├── b
├── c
$ rsync -a a b; tree
├── a
│   ├── 1
│   └── 2
├── b
│   └── a
│       ├── 1
│       └── 2
├── c
$ rsync -a a/ c; tree
├── a
│   ├── 1
│   └── 2
├── b
│   └── a
│       ├── 1
│       └── 2
├── c
│   ├── 1
│   └── 2
```

`File#expand_path` is called on the `src` to support relative path constructs. Previously, a forward slash (`/`) was hardcoded into the result. #173 removed this hardcoded `/`. `File#expand_path` removes `/`, thus making it impossible to pass `src` containing a `/` to eventually be given to sync `cmd` as an argument. This prevent us from being able to sync directories as was done between `a` and `c`