### PR TITLE
Fix the 'compose-force-build' global option

### DIFF
--- a/lib/docker-sync/compose.rb
+++ b/lib/docker-sync/compose.rb
@@ -44,9 +44,9 @@ class ComposeManager
     say_status 'ok','starting compose',:green
     options = Hash.new
     if @global_options['compose-force-build']
-      options['build'] = true
+      options[:build] = true
     end
-    @compose_session.up(options)
+    @compose_session.up(**options)
   end
 
   def stop


### PR DESCRIPTION
The up method in `Docker::Compose::Session.up` takes the parameters:

```ruby
def up(*services, build: false, ...)
```

Previously, the options hash was being passed as a positional argument,
which caused the error:

    'up' failed with status 'pid 1234 exit 1': No such service: {"build"=>true}

when `compose-force-build` was set to `true` in the global options in docker-sync.yml