### PR TITLE
Change docker-compose req to '~> 1.0.2' in gemspec

### DIFF
--- a/docker-sync.gemspec
+++ b/docker-sync.gemspec
@@ -12,6 +12,6 @@ Gem::Specification.new do |s|
   s.required_ruby_version = '>= 2.0'
   s.add_runtime_dependency 'thor', '~> 0.19', '>= 0.19.0'
   s.add_runtime_dependency 'gem_update_checker', '~> 0.2.0', '>= 0.2.0'
-  s.add_runtime_dependency 'docker-compose', '~> 1.0', '>= 1.0.2'
+  s.add_runtime_dependency 'docker-compose', '~> 1.0.2'
   s.add_runtime_dependency 'terminal-notifier', '1.6.3'
 end


### PR DESCRIPTION
There is a [1.4.0.alpha1 version of docker-compose on rubygems](https://rubygems.org/gems/docker-compose/versions/1.4.0.alpha1) that is completely incompatible with the 1.0.x API. Oddly, it is more than a year older than the most recent 1.0.x release (1.0.3), so I'm assuming that it is some sort of mistake. I've changed the gemspec version constraint to prevent that release from being installed.