### PR TITLE
support passing & auto-translating prefer options to unison

### DIFF
--- a/lib/docker-sync/sync_strategy/unison.rb
+++ b/lib/docker-sync/sync_strategy/unison.rb
@@ -121,6 +121,7 @@ module Docker_Sync
         args.push(@options['src'])
         args.push('-auto')
         args.push('-batch')
+        args.push(sync_prefer) if @options.key?('sync_prefer')
         args.push(@options['sync_args']) if @options.key?('sync_args')
         sync_host_port = get_host_port(get_container_name, UNISON_CONTAINER_PORT)
         args.push("socket://#{@options['sync_host_ip']}:#{sync_host_port}")
@@ -129,6 +130,14 @@ module Docker_Sync
           raise('Unison does not support sync_group, sync_groupid - please use rsync if you need that')
         end
         return args
+      end
+
+      def sync_prefer
+        case @options['sync_prefer']
+        when 'src' then "-prefer #{@options['src']}"
+        when 'dest' then "-prefer #{@options['dest']}"
+        else "-prefer #{@options['sync_prefer']}"
+        end
       end
 
       def start_container


### PR DESCRIPTION
valid value for `-prefer` are one of the `root` (in our case `src` or `dest`) or one of the special values of `newer` and `older`

while it is possible to pass in `-prefer` to unison via `sync_args`, since `root` are absolute path, it is desirable for it to be automatically translated from either `src` or `dest`, to make it reusable by different member of the team, since people will have different absolute path for the same project