### PR TITLE
Add daemonize option to 'docker-sync start', closes #51, replaces #65

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,6 +2,7 @@ PATH
   remote: .
   specs:
     docker-sync (0.1.5)
+      daemons (~> 1.2, >= 1.2.3)
       docker-compose (~> 1.0, >= 1.0.2)
       dotenv (~> 2.1, >= 2.1.1)
       gem_update_checker (~> 0.2.0, >= 0.2.0)
@@ -12,6 +13,7 @@ GEM
   remote: https://rubygems.org/
   specs:
     backticks (1.0.0)
+    daemons (1.2.4)
     docker-compose (1.0.3)
       backticks (~> 1.0)
     dotenv (2.1.1)

--- a/docker-sync.gemspec
+++ b/docker-sync.gemspec
@@ -15,4 +15,5 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'docker-compose', '~> 1.0', '>= 1.0.2'
   s.add_runtime_dependency 'terminal-notifier', '1.6.3'
   s.add_runtime_dependency 'dotenv', '~> 2.1', '>= 2.1.1'
+  s.add_runtime_dependency 'daemons', '~> 1.2', '>= 1.2.3'
 end

--- a/lib/docker-sync/sync_manager.rb
+++ b/lib/docker-sync/sync_manager.rb
@@ -97,6 +97,7 @@ module Docker_sync
     end
 
     def init_sync_processes(sync_name = nil)
+      return if @sync_processes.size != 0
       if sync_name.nil?
         @config_syncs.each { |name, sync_configuration|
           @sync_processes.push(create_sync(name, sync_configuration))
@@ -121,6 +122,13 @@ module Docker_sync
       init_sync_processes(sync_name)
       @sync_processes.each { |sync_process|
         sync_process.sync
+      }
+    end
+
+    def start_container(sync_name = nil)
+      init_sync_processes(sync_name)
+      @sync_processes.each { |sync_process|
+        sync_process.start_container
       }
     end
 

--- a/lib/docker-sync/sync_process.rb
+++ b/lib/docker-sync/sync_process.rb
@@ -93,6 +93,10 @@ module Docker_Sync
       @sync_strategy.sync
     end
 
+    def start_container
+      @sync_strategy.start_container
+    end
+
     def watch
       @watch_strategy.run
     end

--- a/tasks/sync/sync.thor
+++ b/tasks/sync/sync.thor
@@ -3,6 +3,7 @@ require 'docker-sync/config'
 require 'docker-sync/preconditions'
 require 'docker-sync/update_check'
 require 'docker-sync/upgrade_check'
+require 'daemons'
 
 class Sync < Thor
 
@@ -10,76 +11,58 @@ class Sync < Thor
   class_option :sync_name, :aliases => '-n',:type => :string, :desc => 'If given, only this sync configuration will be references/started/synced'
 
   desc 'start', 'Start all sync configurations in this project'
+  method_option :daemon, :aliases => '-d', :default => false, :type => :boolean, :desc => 'Run in the background'
+  method_option :app_name, :aliases => '--name', :default => 'dsync', :type => :string, :desc => 'App name used in PID and OUTPUT file name for Daemon'
+  method_option :dir, :aliases => '--dir', :default => '/tmp', :type => :string, :desc => 'Full path to PID and OUTPUT file Directory'
+  method_option :logd, :aliases => '--logd', :default => true, :type => :boolean, :desc => 'To log OUPUT to file on Daemon or not'
   def start
     # do run update check in the start command only
-    updates = UpdateChecker.new
-    updates.run
-    upgrades = UpgradeChecker.new
-    upgrades.run
-    begin
-      Preconditions::check_all_preconditions
-    rescue Exception => e
-      say_status 'error', e.message, :red
-      exit 1
-    end
+    UpdateChecker.new().run
+    UpgradeChecker.new().run
 
-    if options[:config]
-      config_path = options[:config]
-    else
-      begin
-        config_path = DockerSyncConfig::project_config_path
-      rescue Exception => e
-        say_status 'error', e.message, :red
-        return
-      end
+    config_path = config_preconditions
+
+    start_dir = Dir.pwd
+    daemonize if options['daemon']
+
+    Dir.chdir(start_dir) do
+      @sync_manager = Docker_sync::SyncManager.new(:config_path => config_path)
+      @sync_manager.run(options[:sync_name])
+      @sync_manager.join_threads
     end
-    @sync_manager = Docker_sync::SyncManager.new(:config_path => config_path)
-    @sync_manager.run(options[:sync_name])
-    @sync_manager.join_threads
+  end
+
+  desc 'stop', 'Stop docker-sync daemon'
+  method_option :app_name, :aliases => '--name', :default => 'dsync', :type => :string, :desc => 'App name used in PID and OUTPUT file name for Daemon'
+  method_option :dir, :aliases => '--dir', :default => '/tmp', :type => :string, :desc => 'Full path to PID and OUTPUT file Directory'
+  def stop
+    config_preconditions
+
+    begin
+      pid = File.read("#{options['dir']}/#{options['app_name']}.pid")
+      # Send INT signal to all processes in given Group PID
+      Process.kill(:INT, -(Process.getpgid(pid.to_i)))
+      say_status 'shutdown', 'Background dsync has been stopped'
+    rescue Errno::ESRCH, Errno::ENOENT => e
+      say_status 'error', e.message, :red
+      say_status(
+        'error', 'Check if your PIDFILE and process with such PID exists', :red
+      )
+    end
   end
 
   desc 'sync', 'sync - do not start a watcher'
   def sync
-    begin
-      Preconditions::check_all_preconditions
-    rescue Exception => e
-      say_status 'error', e.message, :red
-      exit 1
-    end
+    config_path = config_preconditions
 
-    if options[:config]
-      config_path = options[:config]
-    else
-      begin
-        config_path = DockerSyncConfig::project_config_path
-      rescue Exception => e
-        say_status 'error', e.message, :red
-        return
-      end
-    end
     @sync_manager = Docker_sync::SyncManager.new(:config_path => config_path)
     @sync_manager.sync(options[:sync_name])
   end
 
   desc 'clean', 'Stop and clean up all sync endpoints'
   def clean
-    begin
-      Preconditions::check_all_preconditions
-    rescue Exception => e
-      say_status 'error', e.message, :red
-      exit 1
-    end
+    config_path = config_preconditions
 
-    if options[:config]
-      config_path = options[:config]
-    else
-      begin
-        config_path = DockerSyncConfig::project_config_path
-      rescue Exception => e
-        say_status 'error', e.message, :red
-        return
-      end
-    end
     @sync_manager = Docker_sync::SyncManager.new(:config_path => config_path)
     @sync_manager.clean(options[:sync_name])
     say_status 'success', 'Finished cleanup. Removed stopped, removed sync container and removed their volumes', :green
@@ -88,23 +71,7 @@ class Sync < Thor
   desc 'list', 'List all sync-points of the project configuration path'
   method_option :verbose, :default => false, :type => :boolean, :desc => 'Verbose output'
   def list
-    begin
-      Preconditions::check_all_preconditions
-    rescue Exception => e
-      say_status 'error', e.message, :red
-      exit 1
-    end
-
-    if options[:config]
-      config_path = options[:config]
-    else
-      begin
-        config_path = DockerSyncConfig::project_config_path
-      rescue Exception => e
-        say_status 'error', e.message, :red
-        return
-      end
-    end
+    config_path = config_preconditions
 
     say_status 'ok',"Found configuration at #{config_path}"
     @sync_manager = Docker_sync::SyncManager.new(:config_path => config_path)
@@ -114,4 +81,37 @@ class Sync < Thor
       print_table(config) if options['verbose']
     end
   end
+
+  no_tasks do
+    def config_preconditions
+      begin
+        Preconditions::check_all_preconditions
+      rescue Exception => e
+        say_status 'error', e.message, :red
+        exit 1
+      end
+
+      return options[:config] if options[:config]
+
+      begin
+        DockerSyncConfig::project_config_path
+      rescue Exception => e
+        say_status 'error', e.message, :red
+        exit 1
+      end
+    end
+
+    def daemonize
+      dopts = {
+        app_name: options['app_name'],
+        dir_mode: :normal,
+        dir: options['dir'],
+        log_output: options['logd']
+      }
+
+      say_status 'success', 'Starting Docker-Sync in the background', :green
+      Daemons.daemonize(dopts)
+    end
+  end
+
 end

--- a/tasks/sync/sync.thor
+++ b/tasks/sync/sync.thor
@@ -110,6 +110,11 @@ class Sync < Thor
     end
 
     def daemonize
+      # If we're daemonizing, run a sync first to ensure the containers exist so that a docker-compose up won't fail:
+      @sync_manager.start_container(options[:sync_name])
+      # the existing strategies' start_container will also sync, but just in case a strategy doesn't, sync now:
+      @sync_manager.sync(options[:sync_name])
+
       dopts = {
         app_name: @app_name,
         dir_mode: :normal,

--- a/tasks/sync/sync.thor
+++ b/tasks/sync/sync.thor
@@ -4,6 +4,7 @@ require 'docker-sync/preconditions'
 require 'docker-sync/update_check'
 require 'docker-sync/upgrade_check'
 require 'daemons'
+require 'fileutils'
 
 class Sync < Thor
 
@@ -12,8 +13,8 @@ class Sync < Thor
 
   desc 'start', 'Start all sync configurations in this project'
   method_option :daemon, :aliases => '-d', :default => false, :type => :boolean, :desc => 'Run in the background'
-  method_option :app_name, :aliases => '--name', :default => nil, :type => :string, :desc => 'App name used in PID and OUTPUT file name for Daemon'
-  method_option :dir, :aliases => '--dir', :default => '/tmp', :type => :string, :desc => 'Full path to PID and OUTPUT file Directory'
+  method_option :app_name, :aliases => '--name', :default => 'daemon', :type => :string, :desc => 'App name used in PID and OUTPUT file name for Daemon'
+  method_option :dir, :aliases => '--dir', :default => './.docker-sync', :type => :string, :desc => 'Path to PID and OUTPUT file Directory'
   method_option :logd, :aliases => '--logd', :default => true, :type => :boolean, :desc => 'To log OUPUT to file on Daemon or not'
   def start
     # do run update check in the start command only
@@ -22,10 +23,6 @@ class Sync < Thor
 
     config_path = config_preconditions # Preconditions and Define config_path from shared method
     @sync_manager = Docker_sync::SyncManager.new(:config_path => config_path)
-
-    # By default use the first sync point as the name for the daemonized process (if applicable)
-    @app_name = options[:app_name]
-    @app_name ||= @sync_manager.get_sync_points.keys.first
 
     start_dir = Dir.pwd # Set start_dir variable to be equal to pre-daemonized folder, since daemonizing will change dir to '/'
     daemonize if options['daemon']
@@ -37,18 +34,14 @@ class Sync < Thor
   end
 
   desc 'stop', 'Stop docker-sync daemon'
-  method_option :app_name, :aliases => '--name', :default => nil, :type => :string, :desc => 'App name used in PID and OUTPUT file name for Daemon'
-  method_option :dir, :aliases => '--dir', :default => '/tmp', :type => :string, :desc => 'Full path to PID and OUTPUT file Directory'
+  method_option :app_name, :aliases => '--name', :default => 'daemon', :type => :string, :desc => 'App name used in PID and OUTPUT file name for Daemon'
+  method_option :dir, :aliases => '--dir', :default => './.docker-sync', :type => :string, :desc => 'Path to PID and OUTPUT file Directory'
   def stop
     config_path = config_preconditions
     sync_manager = Docker_sync::SyncManager.new(:config_path => config_path)
 
-    # By default use the first sync point as the name for the daemonized process (if applicable)
-    app_name = options[:app_name]
-    app_name ||= sync_manager.get_sync_points.keys.first
-
     begin
-      pid = File.read("#{options['dir']}/#{app_name}.pid") # Read PID from PIDFILE created by Daemons
+      pid = File.read("#{options['dir']}/#{options['app_name']}.pid") # Read PID from PIDFILE created by Daemons
       Process.kill(:INT, -(Process.getpgid(pid.to_i))) # Send INT signal to group PID, which means INT will be sent to all sub-processes and Threads spawned by docker-sync
       say_status 'shutdown', 'Background dsync has been stopped'
     rescue Errno::ESRCH, Errno::ENOENT => e
@@ -110,8 +103,11 @@ class Sync < Thor
     end
 
     def daemonize
+      # Create the directory for the logs/pid if it doesn't already exist:
+      FileUtils.mkpath(options['dir'])
+
       # Check to see if we're already running:
-      pid_file = Daemons::PidFile.find_files(options['dir'], @app_name).first || ''
+      pid_file = Daemons::PidFile.find_files(options['dir'], options['app_name']).first || ''
       if File.file?(pid_file)
         if Daemons::Pid.running?(File.read(pid_file).to_i)
           say_status 'error', "docker-sync already started for #{@app_name}", :red
@@ -125,7 +121,7 @@ class Sync < Thor
       @sync_manager.sync(options[:sync_name])
 
       dopts = {
-        app_name: @app_name,
+        app_name: options['app_name'],
         dir_mode: :normal,
         dir: options['dir'],
         log_output: options['logd']

--- a/tasks/sync/sync.thor
+++ b/tasks/sync/sync.thor
@@ -20,12 +20,12 @@ class Sync < Thor
     UpdateChecker.new().run
     UpgradeChecker.new().run
 
-    config_path = config_preconditions
+    config_path = config_preconditions # Preconditions and Define config_path from shared method
 
-    start_dir = Dir.pwd
+    start_dir = Dir.pwd # Set start_dir variable to be equal to pre-daemonized folder, since daemonizing will change dir to '/'
     daemonize if options['daemon']
 
-    Dir.chdir(start_dir) do
+    Dir.chdir(start_dir) do # We want run these in pre-daemonized folder/directory since provided config_path might not be full_path
       @sync_manager = Docker_sync::SyncManager.new(:config_path => config_path)
       @sync_manager.run(options[:sync_name])
       @sync_manager.join_threads
@@ -36,15 +36,14 @@ class Sync < Thor
   method_option :app_name, :aliases => '--name', :default => 'dsync', :type => :string, :desc => 'App name used in PID and OUTPUT file name for Daemon'
   method_option :dir, :aliases => '--dir', :default => '/tmp', :type => :string, :desc => 'Full path to PID and OUTPUT file Directory'
   def stop
-    config_preconditions
+    config_preconditions # Preconditions, don't need returned back variable
 
     begin
-      pid = File.read("#{options['dir']}/#{options['app_name']}.pid")
-      # Send INT signal to all processes in given Group PID
-      Process.kill(:INT, -(Process.getpgid(pid.to_i)))
+      pid = File.read("#{options['dir']}/#{options['app_name']}.pid") # Read PID from PIDFILE created by Daemons
+      Process.kill(:INT, -(Process.getpgid(pid.to_i))) # Send INT signal to group PID, which means INT will be sent to all sub-processes and Threads spawned by docker-sync
       say_status 'shutdown', 'Background dsync has been stopped'
     rescue Errno::ESRCH, Errno::ENOENT => e
-      say_status 'error', e.message, :red
+      say_status 'error', e.message, :red # Rescue incase PIDFILE does not exist or there is no process with such PID
       say_status(
         'error', 'Check if your PIDFILE and process with such PID exists', :red
       )
@@ -53,7 +52,7 @@ class Sync < Thor
 
   desc 'sync', 'sync - do not start a watcher'
   def sync
-    config_path = config_preconditions
+    config_path = config_preconditions # Preconditions and Define config_path from shared method
 
     @sync_manager = Docker_sync::SyncManager.new(:config_path => config_path)
     @sync_manager.sync(options[:sync_name])
@@ -61,7 +60,7 @@ class Sync < Thor
 
   desc 'clean', 'Stop and clean up all sync endpoints'
   def clean
-    config_path = config_preconditions
+    config_path = config_preconditions # Preconditions and Define config_path from shared method
 
     @sync_manager = Docker_sync::SyncManager.new(:config_path => config_path)
     @sync_manager.clean(options[:sync_name])
@@ -71,7 +70,7 @@ class Sync < Thor
   desc 'list', 'List all sync-points of the project configuration path'
   method_option :verbose, :default => false, :type => :boolean, :desc => 'Verbose output'
   def list
-    config_path = config_preconditions
+    config_path = config_preconditions # Preconditions and Define config_path from shared method
 
     say_status 'ok',"Found configuration at #{config_path}"
     @sync_manager = Docker_sync::SyncManager.new(:config_path => config_path)
@@ -83,7 +82,7 @@ class Sync < Thor
   end
 
   no_tasks do
-    def config_preconditions
+    def config_preconditions # Moved shared preconditions block into separate method to have less/cleaner code
       begin
         Preconditions::check_all_preconditions
       rescue Exception => e
@@ -107,7 +106,7 @@ class Sync < Thor
         dir_mode: :normal,
         dir: options['dir'],
         log_output: options['logd']
-      }
+      } # List of options accepted by Daemonize, can be customized pretty nicely with provided CLI options
 
       say_status 'success', 'Starting Docker-Sync in the background', :green
       Daemons.daemonize(dopts)

--- a/tasks/sync/sync.thor
+++ b/tasks/sync/sync.thor
@@ -110,7 +110,7 @@ class Sync < Thor
       pid_file = Daemons::PidFile.find_files(options['dir'], options['app_name']).first || ''
       if File.file?(pid_file)
         if Daemons::Pid.running?(File.read(pid_file).to_i)
-          say_status 'error', "docker-sync already started for #{@app_name}", :red
+          say_status 'error', "docker-sync already started for this configuration", :red
           exit 1
         end
       end


### PR DESCRIPTION
This PR builds on the excellent initial work by @midN in #65 - but extends it to allow for running multiple sync daemons in an easier manner, ensures that before daemonizing the script we have a running + synchronized container, prevents the same configuration from starting twice, and switches the default logs/pid folder to live alongside the location from which the script was invoked.

This modifies the `start` command to allow for the following options:
* `--daemon` (`-d`), Run in the background (default: false)
* `--app_name` (`--name`), The name to use in the filename for the `pid` and `output` files (default: 'daemon')
* `--dir`, The directory to place the `pid` and `output` files (default: './.docker-sync')
* `--logd`, Whether or not to log the output (default: true)

This also adds the `stop` command to stop the background process. It also takes the `--app_name` and `--dir` arguments.

## Notes:
### New directory:
This will now create a `.docker-sync` directory alongside wherever you invoke the command (if you're asking it to run in the background). You will likely want to add this directory to your `.gitignore` file (or equivalent).

### Invoking with the --config option
I imagine most users will be invoking `docker-sync` without specifying an alternate path to the config file, but it's worth mentioning that if that's your current setup, you should also consider using the `app_name` option or the `dir` option to ensure that your `pid` file won't conflict with other invocations of docker-sync - otherwise you'll get a message saying that it's already running.

### What does it look like when you run it?
Instead of running `docker-sync start` - and then needing to run everything else in a separate tab/session, you can now run `docker-sync start -d` and continue using the same tab/session. If there are any errors you'll see them when it attempts to do the first sync before it goes into the background. If you'd like to see the logs for docker-sync, they default to:
`.docker-sync/daemon.output`

If you're currently relying on using `docker-sync-stack start` - you can continue to do so, or if you prefer to manage your services from `docker-compose` on an individual basis, you can now:
```sh
docker-sync start -d
docker-compose up #[options]
```