### PR TITLE
Mention the availability of daemon mode when starting in non-daemon mode (resolves #234)

### DIFF
--- a/tasks/stack/stack.thor
+++ b/tasks/stack/stack.thor
@@ -37,6 +37,8 @@ class Stack < Thor
       end
     end
 
+    say_status 'note:', 'You can also run docker-sync in the background with docker-sync --daemon'
+
     @sync_manager = Docker_sync::SyncManager.new(:config_path => config_path)
     @sync_manager.run(options[:sync_name])
     global_options = @sync_manager.global_options

--- a/tasks/sync/sync.thor
+++ b/tasks/sync/sync.thor
@@ -25,7 +25,11 @@ class Sync < Thor
     @sync_manager = Docker_sync::SyncManager.new(:config_path => config_path)
 
     start_dir = Dir.pwd # Set start_dir variable to be equal to pre-daemonized folder, since daemonizing will change dir to '/'
-    daemonize if options['daemon']
+    if options['daemon']
+      daemonize
+    else
+      say_status 'note:', 'You can also run docker-sync in the background with --daemon'
+    end
 
     Dir.chdir(start_dir) do # We want run these in pre-daemonized folder/directory since provided config_path might not be full_path
       @sync_manager.run(options[:sync_name])


### PR DESCRIPTION
Resolves #234 

I put it in `docker-sync-stack start` as well - but I can take it out if you'd prefer.
I found it easiest to add it right at the top, after any updates/upgrades (for consistency) - but I can make this a little more invasive if you prefer it showing up after the initial sync...