### PR TITLE
Add docker-sync log task

### DIFF
--- a/tasks/sync/sync.thor
+++ b/tasks/sync/sync.thor
@@ -102,6 +102,7 @@ class Sync < Thor
   method_option :lines, :aliases => '--lines', :default => 100, :type => :numeric, :desc => "Specify number of lines to tail"
   method_option :app_name, :aliases => '--name', :default => 'daemon', :type => :string, :desc => 'App name used in PID and OUTPUT file name for Daemon'
   method_option :dir, :aliases => '--dir', :default => './.docker-sync', :type => :string, :desc => 'Path to PID and OUTPUT file Directory'
+  method_option :follow, :aliases => '-f', :default => false, :type => :boolean, :desc => "Specify if the logs should be streamed"
   def log
     print_daemon_logs
   end
@@ -159,7 +160,11 @@ class Sync < Thor
       end
 
       log_file = File.join(options['dir'], "#{options['app_name']}.log")
-      system("tail -n #{options['lines']} #{log_file}")
+      begin
+        system("tail #{options['follow'] ? '-f ' : ''}-n #{options['lines']} #{log_file}")
+      rescue Interrupt
+        nil
+      end
     end
 
     def daemon_running?

--- a/tasks/sync/sync.thor
+++ b/tasks/sync/sync.thor
@@ -153,8 +153,12 @@ class Sync < Thor
     end
 
     def print_daemon_logs
-      log_file = File.join(options['dir'], "#{options['app_name']}.log")
+      unless daemon_running?
+        say_status 'error', "docker-sync is not running in daemon mode for this configuration", :red
+        exit 1
+      end
 
+      log_file = File.join(options['dir'], "#{options['app_name']}.log")
       system("tail -n #{options['lines']} #{log_file}")
     end
 


### PR DESCRIPTION
Motivation: When I run `docker-sync start -d` in background, it is useful to sometimes look at the logs as unison sometimes fails some sync etc.

Benefits:
* Calling `docker-sync log` is more convenient than always manually calling `tail -n 100 .docker-sync/daemon.log`. 
* It hides the implementation of how the daemon works, so if it is subject to change in future, we can keep the same CLI user interface for getting logs.

Task options:
* Duplicated options from `start` - `--dir` and `--app-name`.
* `--lines=N` specifies number of lines to tail
* `-f | --follow` will stream the log