### PR TITLE
disable unison auto-detection in non osx environment

### DIFF
--- a/lib/docker-sync/preconditions.rb
+++ b/lib/docker-sync/preconditions.rb
@@ -1,12 +1,11 @@
 require 'mkmf'
+require 'rbconfig'
 
 module Preconditions
   def self.check_all_preconditions
     docker_available
     docker_running
-    unison_available
-    unox_available
-    macfsevents_available
+    check_all_unison_preconditions
   end
 
   def self.docker_available
@@ -19,6 +18,19 @@ module Preconditions
     `docker ps`
     if $?.exitstatus > 0
       raise('No docker daemon seems to be running. Did you start your docker-for-mac / docker-machine?')
+    end
+  end
+
+  def self.check_all_unison_preconditions
+    if RbConfig::CONFIG['host_os'] =~ /darwin|mac os/
+      unison_available
+      unox_available
+      macfsevents_available
+    else
+      Thor::Shell::Basic.new.say_status 'warning',
+        "You're running docker-sync under non-osx environment! "\
+        "Please make sure that you've installed unison, and unison-fsmonitor",
+        :red
     end
   end
 

--- a/lib/docker-sync/sync_strategy/unison.rb
+++ b/lib/docker-sync/sync_strategy/unison.rb
@@ -26,9 +26,7 @@ module Docker_Sync
           @docker_image = 'eugenmayer/unison'
         end
         begin
-          Preconditions::unison_available
-          Preconditions::unox_available
-          Preconditions::macfsevents_available
+          Preconditions::check_all_unison_preconditions
         rescue Exception => e
           say_status 'error', "#{@sync_name} has been configured to sync with unison, but no unison available", :red
           say_status 'error', e.message, :red


### PR DESCRIPTION
should also fix #248 

I'm using this in an ubuntu machine, though I had managed to install unison and unison-fsmonitor manually from source (which was working in 0.1.5), new check for phython and macfsevents makes docker-sync unusable outside osx..

This is the lease that we can do to make it runnable again..