### PR TITLE
Better handle an unclean stop of the daemon

### DIFF
--- a/tasks/sync/sync.thor
+++ b/tasks/sync/sync.thor
@@ -93,7 +93,7 @@ class Sync < Thor
     files = Dir[File.join(dir, '*.pid')]
     files.each do |pid_file|
       pid = File.read(pid_file).to_i
-      Process.kill(:INT, -(Process.getpgid(pid)))
+      Process.kill(:INT, -(Process.getpgid(pid))) if Daemons::Pid.running?(pid)
       say_status 'shutdown', 'Background dsync has been stopped'
     end
     # Remove the .docker-sync directory


### PR DESCRIPTION
An unclean stop can leave pid references that will fail to return a pgid - this results in:
```
/usr/local/lib/ruby/gems/2.3.0/gems/docker-sync-0.2.0/tasks/sync/sync.thor:96:in `getpgid': No such process (Errno::ESRCH)
	from /usr/local/lib/ruby/gems/2.3.0/gems/docker-sync-0.2.0/tasks/sync/sync.thor:96:in `block in clean'
	from /usr/local/lib/ruby/gems/2.3.0/gems/docker-sync-0.2.0/tasks/sync/sync.thor:94:in `each'
...
```

This updates the `clean` command to first check if the given `pid` is running so that we can more certain the `getpgid` will work.