### PR TITLE
Print version even with no command (fixes #255)

### DIFF
--- a/tasks/sync/sync.thor
+++ b/tasks/sync/sync.thor
@@ -12,16 +12,20 @@ class Sync < Thor
   class_option :sync_name, :aliases => '-n',:type => :string, :desc => 'If given, only this sync configuration will be references/started/synced'
   class_option :version, :aliases => '-v',:type => :boolean, :default => false, :desc => 'prints out the version of docker-sync and exits'
 
+  desc '--version, -v', 'Prints out the version of docker-sync and exits'
+  def print_version
+    puts UpgradeChecker.get_current_version
+    exit(0)
+  end
+  map %w[--version -v] => :print_version
+
   desc 'start', 'Start all sync configurations in this project'
   method_option :daemon, :aliases => '-d', :default => false, :type => :boolean, :desc => 'Run in the background'
   method_option :app_name, :aliases => '--name', :default => 'daemon', :type => :string, :desc => 'App name used in PID and OUTPUT file name for Daemon'
   method_option :dir, :aliases => '--dir', :default => './.docker-sync', :type => :string, :desc => 'Path to PID and OUTPUT file Directory'
   method_option :logd, :aliases => '--logd', :default => true, :type => :boolean, :desc => 'To log OUPUT to file on Daemon or not'
   def start
-    if options[:version]
-      puts UpgradeChecker.get_current_version
-      exit(0)
-    end
+    print_version if options[:version]
     # do run update check in the start command only
     UpdateChecker.new().run
     UpgradeChecker.new().run
@@ -46,10 +50,7 @@ class Sync < Thor
   method_option :app_name, :aliases => '--name', :default => 'daemon', :type => :string, :desc => 'App name used in PID and OUTPUT file name for Daemon'
   method_option :dir, :aliases => '--dir', :default => './.docker-sync', :type => :string, :desc => 'Path to PID and OUTPUT file Directory'
   def stop
-    if options[:version]
-      puts UpgradeChecker.get_current_version
-      exit(0)
-    end
+    print_version if options[:version]
 
     config_path = config_preconditions
     sync_manager = Docker_sync::SyncManager.new(:config_path => config_path)
@@ -68,10 +69,7 @@ class Sync < Thor
 
   desc 'sync', 'just sync - do not start a watcher though'
   def sync
-    if options[:version]
-      puts UpgradeChecker.get_current_version
-      exit(0)
-    end
+    print_version if options[:version]
 
     config_path = config_preconditions # Preconditions and Define config_path from shared method
 
@@ -81,10 +79,7 @@ class Sync < Thor
 
   desc 'clean', 'Stop and clean up all sync endpoints'
   def clean
-    if options[:version]
-      puts UpgradeChecker.get_current_version
-      exit(0)
-    end
+    print_version if options[:version]
 
     config_path = config_preconditions # Preconditions and Define config_path from shared method
 
@@ -111,10 +106,7 @@ class Sync < Thor
   method_option :logd, :aliases => '--logd', :default => true, :type => :boolean, :desc => 'To log OUPUT to file on Daemon or not'
   method_option :app_name, :aliases => '--name', :default => 'daemon', :type => :string, :desc => 'App name used in PID and OUTPUT file name for Daemon'
   def logs
-    if options[:version]
-      puts UpgradeChecker.get_current_version
-      exit(0)
-    end
+    print_version if options[:version]
 
     print_daemon_logs
   end
@@ -122,10 +114,7 @@ class Sync < Thor
   desc 'list', 'List all sync-points of the project configuration path'
   method_option :verbose, :default => false, :type => :boolean, :desc => 'Verbose output'
   def list
-    if options[:version]
-      puts UpgradeChecker.get_current_version
-      exit(0)
-    end
+    print_version if options[:version]
 
     config_path = config_preconditions # Preconditions and Define config_path from shared method
 


### PR DESCRIPTION
The downside to this approach (leaving it in the other commands as well) is that it will print out twice in the list when you get help. I didn't see an easy way to have an option that's hidden, or a command that's undocumented - so if you know of a way I'll happily change it.

This should resolve #255