### PR TITLE
Show a warning rather than an error

### DIFF
--- a/tasks/sync/sync.thor
+++ b/tasks/sync/sync.thor
@@ -152,7 +152,7 @@ class Sync < Thor
 
       # Check to see if we're already running:
       if daemon_running?
-        say_status 'error', "docker-sync already started for this configuration", :red
+        say_status 'warning', 'docker-sync already started for this configuration', :yellow
         exit 1
       end
 


### PR DESCRIPTION
If the sync is already running, then it may look nicer to show a warning message rather than a red error message. That way if someone has it as part of a start-up script that they end up running more than once they'll just get a yellow warning message rather than a worrisome red error.
(a few of my coworkers noticed this, which means it's likely others will as well)