### PR TITLE
Make 'dest' optional in sync configuration

### DIFF
--- a/example/docker-sync.yml
+++ b/example/docker-sync.yml
@@ -25,7 +25,6 @@ syncs:
     # common options
     # see rsync documentation for all these common options
     src: './data4/'
-    dest: '/data'
     # be aware, this only gives you a notification on the initial sync, not the syncs after changes. this is a difference
     # to the rsync implementation
     notify_terminal: true
@@ -67,23 +66,10 @@ syncs:
     # good thing incase you are developing and want to know exactly when your changes took effect.
     notify_terminal: true
     # which folder to watch / sync from - you can use tilde, it will get expanded.
-
-    # if you want to sync a full directory, set it up like this:
-    # This will create /docker/path/to/my/code/ on the container
-    #
-    # src: '/local/path/to/my/code'
-    # dest: '/docker/path/to/my/'
-
-    # if you want to sync a single file, set it up like this
-    # This will create /docker/path/to/file.ini on the container
-    #
-    # src: '/local/path/to/file.ini'
-    # dest: '/docker/path/to'
-
-    # TODO: include other examples of how to set these up to get the desired paths
-
+    # the contents of this directory will be synchronized to the Docker volume with the name of this sync entry ('rsync-sync' here)
     src: './data1/'
-    # which destination on the sync-container. Since you will use volumes_from to mount this, this should match your code-deployment location in the real container
+    # destination on the sync-container. This is optional and defaults to '/sync'.
+    # since you will in most cases mount the volume using the volume name ('rsync-sync' in this example) this value has little relevance
     dest: '/var/www'
     # when a port of a container is exposed, on which IP does it get exposed. Localhost for docker for mac, something else for docker-machine
     sync_host_ip: '127.0.0.1'

--- a/lib/docker-sync/sync_manager.rb
+++ b/lib/docker-sync/sync_manager.rb
@@ -34,7 +34,6 @@ module Docker_sync
     end
     
     def load_configuration
-      
       # try to interpolate supplied inline config string, alternatively load the configuration file
       config = ConfigTemplate::interpolate_config_string(@config_string || load_configuration_file())
 
@@ -72,6 +71,11 @@ module Docker_sync
           end
         end
 
+        # set default value for 'dest'
+        if !@config_syncs[name].key?('dest')
+          @config_syncs[name]['dest'] = '/sync'
+        end
+
         # for each strategy check if a custom image has been defined and inject that into the sync-endpoints
         # which do fit for this strategy
         %w(rsync unison).each do |strategy|
@@ -95,7 +99,7 @@ module Docker_sync
     end
 
     def validate_sync_config(name, sync_config)
-      config_mandatory = %w[src dest]
+      config_mandatory = %w[src]
       config_mandatory.push('sync_host_port') if sync_config['sync_strategy'] == 'rsync' #TODO: Implement autodisovery for other strategies
       config_mandatory.each do |key|
         raise ("#{name} does not have #{key} configuration value set - this is mandatory") unless sync_config.key?(key)


### PR DESCRIPTION
If not given, use default value '/sync'.

This is a very minimal change for #256 . I tried it with unison - not sure about rsync since the trailing '/'  has special meaning there.