### PR TITLE
make name of env-file configureable

### DIFF
--- a/lib/docker-sync/config.rb
+++ b/lib/docker-sync/config.rb
@@ -8,7 +8,12 @@ require 'docker-sync/config_template'
 module DockerSyncConfig
 
   def initialize(options)
-    Dotenv.load
+    load_dotenv
+  end
+
+  def self.load_dotenv
+    env_file = ENV.fetch('DOCKER_SYNC_ENV_FILE', '.env')
+    Dotenv.load(env_file)
   end
 
   def self.global_config_location

--- a/lib/docker-sync/sync_manager.rb
+++ b/lib/docker-sync/sync_manager.rb
@@ -6,6 +6,7 @@ require 'docker-sync/execution'
 require 'yaml'
 require 'dotenv'
 require 'docker-sync/config_template'
+require 'docker-sync/config'
 
 module Docker_sync
   class SyncManager
@@ -16,7 +17,7 @@ module Docker_sync
     @config_path
 
     def initialize(options)
-      Dotenv.load
+      DockerSyncConfig.load_dotenv
 
       @sync_processes = []
       @config_syncs = []


### PR DESCRIPTION
Use DOCKER_SYNC_ENV_FILE to set filename of env-file.
Defaults to ".env"

This takes care of #254 