### PR TITLE
Return an error exit code when trying to stop a daemon which is not running

### DIFF
--- a/tasks/sync/sync.thor
+++ b/tasks/sync/sync.thor
@@ -61,9 +61,8 @@ class Sync < Thor
       say_status 'shutdown', 'Background dsync has been stopped'
     rescue Errno::ESRCH, Errno::ENOENT => e
       say_status 'error', e.message, :red # Rescue incase PIDFILE does not exist or there is no process with such PID
-      say_status(
-        'error', 'Check if your PIDFILE and process with such PID exists', :red
-      )
+      say_status 'error', 'Check if your PIDFILE and process with such PID exists', :red
+      exit(69) # EX_UNAVAILABLE (see `man sysexits` or `/usr/include/sysexits.h`)
     end
   end
 


### PR DESCRIPTION
## Problem

When `docker-sync-daemon` is not started, running `docker-sync-daemon stop` outputs an error message but exits with a success error message (`0`, _aka_ `EX_OK`).

## Solution

According to `man sysexits` (which documents `/usr/include/sysexits.h` on BSD systems), we might want to exit with error code `69` (_aka_ `EX_UNAVAILABLE`):

> **EX_UNAVAILABLE (69)**   A service is unavailable.  This can occur if a support program or file does not exist.  This can also be used as a catchall message when something you wanted to do doesn't work, but you don't know why.

## Exemple

Before this PR (without `docker-sync-daemon` started):

```shell
$ docker-sync-daemon stop
       error  No such file or directory - ./.docker-sync/kyero.pid
       error  Check if your PIDFILE and process with such PID exists
$ echo $?
0
```

After this PR:

```shell
$ docker-sync-daemon stop
       error  No such file or directory - ./.docker-sync/kyero.pid
       error  Check if your PIDFILE and process with such PID exists
$ echo $?
69
```