### PR TITLE
Add `max_attempt` options

### DIFF
--- a/example/docker-sync.yml
+++ b/example/docker-sync.yml
@@ -18,6 +18,8 @@ options:
   unison_image: 'eugenmayer/unison'
   # can be docker-sync, thor or auto and defines, how the sync will be invoked on the cli. Mostly depending if your are using docker-sync solo, scaffolded or in development ( thor )
   cli_mode: 'auto'
+  # optional, maximum number of attempts for unison waiting for the success exit status. The default is 5 attempts (1-second sleep for each attempt). Only used in unison.
+  max_attempt: 5
 syncs:
   unison-sync:
     # unison 2 way-sync, default since 0.2.0


### PR DESCRIPTION
Explanation and example for `max_attempt` option

Related with https://github.com/EugenMayer/docker-sync/pull/291