### PR TITLE
bugfix on missing config_path when using fswatch as watch_strategy

### DIFF
--- a/lib/docker-sync/config/project_config.rb
+++ b/lib/docker-sync/config/project_config.rb
@@ -26,7 +26,10 @@ module DockerSync
 
     def initialize(config_path: nil, config_string: nil)
       if config_string.nil?
-        config_path = DockerSync::ConfigLocator.lookup_project_config_path
+        if config_path.nil? || config_path.empty?
+          config_path = DockerSync::ConfigLocator.lookup_project_config_path
+        end
+
         load_project_config(config_path)
       else
         @config = DockerSync::ConfigSerializer.default_deserializer_string(config_string)

--- a/lib/docker-sync/preconditions/preconditions_linux.rb
+++ b/lib/docker-sync/preconditions/preconditions_linux.rb
@@ -2,6 +2,19 @@ module DockerSync
   module Preconditions
     class Linux
       def check_all_preconditions(config)
+        return unless should_run_precondition?
+
+        docker_available
+        docker_running
+
+        if config.unison_required?
+          unison_available
+        end
+
+        if config.rsync_required?
+          rsync_available
+          fswatch_available
+        end
       end
 
       def docker_available
@@ -18,7 +31,12 @@ module DockerSync
 
       def unison_available
       end
-    end
 
+      private
+
+      def should_run_precondition?(silent: false)
+        true
+      end
+    end
   end
 end

--- a/lib/docker-sync/preconditions/preconditions_osx.rb
+++ b/lib/docker-sync/preconditions/preconditions_osx.rb
@@ -59,7 +59,7 @@ module DockerSync
       def fswatch_available
         if should_run_precondition?
           if (find_executable0 'fswatch').nil?
-            cmd1 = 'brew install fswatch"'
+            cmd1 = 'brew install fswatch'
 
             Thor::Shell::Basic.new.say_status 'warning', 'No fswatch available. Install it by "brew install fswatch Trying to install now', :red
             if Thor::Shell::Basic.new.yes?('I will install fswatch using brew for you? (y/N)')
@@ -76,7 +76,7 @@ module DockerSync
 
       def should_run_precondition?(silent = false)
         unless has_brew?
-          Thor::Shell::Basic.new.say_status 'inf', 'Not running any precondition checks since you have no brew and that is unsupported. Is all up to you know.', :white unless silent
+          Thor::Shell::Basic.new.say_status 'info', 'Not running any precondition checks since you have no brew and that is unsupported. Is all up to you know.', :white unless silent
           return false
         end
         return true

--- a/lib/docker-sync/sync_manager.rb
+++ b/lib/docker-sync/sync_manager.rb
@@ -163,6 +163,7 @@ module Docker_sync
             config_string: options[:config_string]
           )
 
+        @config_path = config.config_path
         @config_global = config['options'] || {}
         @config_syncs = config['syncs']
         upgrade_syncs_config

--- a/spec/lib/docker-sync/global_config_spec.rb
+++ b/spec/lib/docker-sync/global_config_spec.rb
@@ -65,8 +65,6 @@ describe DockerSync::GlobalConfig do
       config.update! 'new' => 'value'
 
       updated_config = DockerSync::GlobalConfig.load
-      puts updated_config.to_h
-
       expect(updated_config.to_h).to include('new' => 'value')
     end
   end

--- a/spec/lib/docker-sync/preconditions_spec.rb
+++ b/spec/lib/docker-sync/preconditions_spec.rb
@@ -73,7 +73,7 @@ describe DockerSync::Preconditions::Strategy do
         Singleton.__init__(DockerSync::Preconditions::Strategy)
         allow(subject.strategy).to receive(:has_brew?) { false }
 
-        expect(subject.strategy.send(:should_run_precondition?)).to eq(false)
+        expect(subject.strategy.send(:should_run_precondition?, true)).to eq(false)
       end
     end
 
@@ -87,18 +87,16 @@ describe DockerSync::Preconditions::Strategy do
         Singleton.__init__(DockerSync::Preconditions::Strategy)
         allow(subject.strategy).to receive(:has_brew?) { true }
 
-        expect(subject.strategy.send(:should_run_precondition?)).to eq(true)
+        expect(subject.strategy.send(:should_run_precondition?, true)).to eq(true)
       end
     end
 
     context 'without docker installed, do raise an exception' do
       it do
-
         Singleton.__init__(DockerSync::Preconditions::Strategy)
 
         allow(subject.strategy).to receive(:docker_available).and_raise('docker not here')
         allow(subject.strategy).to receive(:should_run_precondition?) { true }
-        allow(subject.strategy).to receive(:has_brew?) { true }
 
         use_fixture 'simplest' do
           expect { subject.check_all_preconditions(load_config) }.to raise_error('docker not here')

--- a/spec/lib/docker-sync/project_config_spec.rb
+++ b/spec/lib/docker-sync/project_config_spec.rb
@@ -129,6 +129,18 @@ describe DockerSync::ProjectConfig do
           }.to raise_error("Config could not be loaded from #{config_path} - it does not exist")
         end
       end
+
+      context 'given config path is an empty string' do
+        let(:config_path) { '' }
+
+        it 'fall back into default project config' do
+          expect(DockerSync::ConfigLocator).to receive(:lookup_project_config_path).and_call_original
+
+          use_fixture('simplest') do
+            subject
+          end
+        end
+      end
     end
 
     describe 'explicit config_string' do


### PR DESCRIPTION
2bf2a6d0348f85e90924821b4b0e9940c0372292 fix it by removing support for `config_path`, but the root issue is we forgot to set `@config_path` in `SyncManager`, which are used in [this line](https://github.com/EugenMayer/docker-sync/blob/be86d1bf546bf964d8ba6970af51caf5ac558db2/lib/docker-sync/sync_manager.rb#L31)

so in this PR, I brought back support for `config_path`, and fix fswatch by properly setting `@config_path` (+ some extras :grin: )...