### PR TITLE
bugfix: method_missing watch_fork on dummy & fswatch watch strategy

### DIFF
--- a/lib/docker-sync/watch_strategy/dummy.rb
+++ b/lib/docker-sync/watch_strategy/dummy.rb
@@ -9,11 +9,13 @@ module Docker_Sync
 
       @options
       @sync_name
+      @watch_fork
       @watch_thread
 
       def initialize(sync_name, options)
         @options = options
         @sync_name = sync_name
+        @watch_fork = nil
         @watch_thread = nil
       end
 
@@ -31,6 +33,10 @@ module Docker_Sync
       end
 
       def watch_options
+      end
+
+      def watch_fork
+        return @watch_fork
       end
 
       def watch_thread

--- a/lib/docker-sync/watch_strategy/fswatch.rb
+++ b/lib/docker-sync/watch_strategy/fswatch.rb
@@ -82,6 +82,11 @@ module Docker_Sync
         # append the actual operation
         return "#{sync_command}sync"
       end
+
+      def watch_fork
+        return nil
+      end
+
       def watch_thread
         return @watch_thread
       end


### PR DESCRIPTION
called from: https://github.com/EugenMayer/docker-sync/blob/4766014b8faed574e3153ff244177e8e0fdf5224/lib/docker-sync/sync_process.rb#L90