### PR TITLE
add sync strategy for native docker volume

### DIFF
--- a/example/docker-sync.yml
+++ b/example/docker-sync.yml
@@ -23,8 +23,18 @@ options:
   # optional, default: pwd, root directory to be used when transforming sync src into absolute path, accepted values: pwd (current working directory), config_path (the directory where docker-sync.yml is found)
   project_root: 'pwd'
 syncs:
+  default-sync:
+    # os aware sync strategy, default to unison under osx, and native docker volume under linux
+    sync_strategy: 'default'
+    # which folder to watch / sync from - you can use tilde, it will get expanded.
+    # the contents of this directory will be synchronized to the Docker volume with the name of this sync entry ('default-sync' here)
+    src: './default-data/'
+
+    # other unison options can also be specified here, which will be used when run under osx,
+    # and ignored when run under linux
+
   unison-sync:
-    # unison 2 way-sync, default since 0.2.0
+    # unison 2 way-sync
     sync_strategy: 'unison'
     # common options
     # see rsync documentation for all these common options
@@ -73,9 +83,6 @@ syncs:
     # which folder to watch / sync from - you can use tilde, it will get expanded.
     # the contents of this directory will be synchronized to the Docker volume with the name of this sync entry ('rsync-sync' here)
     src: './data1/'
-    # destination on the sync-container. This is optional and defaults to '/sync'.
-    # since you will in most cases mount the volume using the volume name ('rsync-sync' in this example) this value has little relevance
-    dest: '/var/www'
     # when a port of a container is exposed, on which IP does it get exposed. Localhost for docker for mac, something else for docker-machine
     # default is 'auto', which means, your docker-machine/docker host ip will be detected automatically. If you set this to a concrete IP, this ip will be enforced
     sync_host_ip: 'auto'

--- a/lib/docker-sync/sync_process.rb
+++ b/lib/docker-sync/sync_process.rb
@@ -2,6 +2,7 @@ require 'thor/shell'
 # noinspection RubyResolve
 require 'docker-sync/sync_strategy/rsync'
 require 'docker-sync/sync_strategy/unison'
+require 'docker-sync/sync_strategy/native'
 # noinspection RubyResolve
 require 'docker-sync/watch_strategy/fswatch'
 require 'docker-sync/watch_strategy/dummy'
@@ -42,6 +43,8 @@ module Docker_Sync
         @sync_strategy = Docker_Sync::SyncStrategy::Rsync.new(@sync_name, @options)
       when 'unison'
         @sync_strategy = Docker_Sync::SyncStrategy::Unison.new(@sync_name, @options)
+      when 'native'
+        @sync_strategy = Docker_Sync::SyncStrategy::Native.new(@sync_name, @options)
       else
         raise "Unknown sync_strategy #{@options['sync_strategy']}"
       end

--- a/lib/docker-sync/sync_strategy/native.rb
+++ b/lib/docker-sync/sync_strategy/native.rb
@@ -1,0 +1,69 @@
+require 'thor/shell'
+require 'docker-sync/preconditions/strategy'
+
+module Docker_Sync
+  module SyncStrategy
+    class Native
+      include Thor::Shell
+
+      @options
+      @sync_name
+
+      def initialize(sync_name, options)
+        @sync_name = sync_name
+        @options = options
+
+        begin
+          DockerSync::Preconditions::Strategy.instance.docker_available
+        rescue Exception => e
+          say_status 'error', "#{@sync_name} has been configured to sync with native docker volume, but docker is not found", :red
+          say_status 'error', e.message, :red
+          exit 1
+        end
+      end
+
+      def run
+        create_volume
+      end
+
+      def sync
+        # noop
+      end
+
+      def get_volume_name
+        @sync_name
+      end
+
+      def start_container
+        # noop
+      end
+
+      def clean
+        delete_volume
+      end
+
+      def stop
+        # noop
+      end
+
+      private
+
+      def create_volume
+        run_cmd "docker volume create --opt type=none --opt device=\"#{@options['src']}\" --opt o=bind "\
+          "--name #{get_volume_name}"
+
+        say_status 'success', "Docker volume for #{get_volume_name} created", :white
+      end
+
+      def delete_volume
+        run_cmd "docker volume ls -q | grep #{get_volume_name} && docker volume rm #{get_volume_name}"
+      end
+
+      def run_cmd(cmd)
+        say_status 'command', cmd, :white if @options['verbose']
+
+        `#{cmd}`
+      end
+    end
+  end
+end

--- a/spec/lib/docker-sync/preconditions_spec.rb
+++ b/spec/lib/docker-sync/preconditions_spec.rb
@@ -21,9 +21,9 @@ describe DockerSync::Preconditions::Strategy do
         allow(subject.strategy).to receive(:unison_available) { true }
         expect(subject).to receive(:unison_available)
 
-        use_fixture 'simplest' do
+        use_fixture 'unison' do
           config = load_config
-          Docker_Sync::SyncStrategy::Unison.new('simplest-sync',config['syncs']['simplest-sync'])
+          Docker_Sync::SyncStrategy::Unison.new('appcode-unison-sync',config['syncs']['appcode-unison-sync'])
         end
       end
     end
@@ -41,7 +41,7 @@ describe DockerSync::Preconditions::Strategy do
         expect(subject.strategy).to receive(:unison_available)
         #expect(described_class.instance.strategy).to receive(:unox_available)
 
-        use_fixture 'simplest' do
+        use_fixture 'unison' do
           subject.check_all_preconditions(load_config)
         end
       end

--- a/spec/lib/docker-sync/project_config_spec.rb
+++ b/spec/lib/docker-sync/project_config_spec.rb
@@ -1,6 +1,9 @@
 require 'docker-sync/config/project_config'
 
 describe DockerSync::ProjectConfig do
+  let(:default_sync_strategy) { OS.linux? ? 'native' : 'unison' }
+  let(:default_watch_strategy) { OS.linux? ? 'dummy' : 'unison' }
+
   subject { described_class.new }
 
   describe '#initialize' do
@@ -16,8 +19,8 @@ describe DockerSync::ProjectConfig do
               'simplest-sync' => {
                 'src' => "#{fixture_path 'simplest'}/app",
                 'dest' => '/var/www',
-                'sync_strategy' => 'unison',
-                'watch_strategy' => 'unison'
+                'sync_strategy' => default_sync_strategy,
+                'watch_strategy' => default_watch_strategy
               }
             }
           })
@@ -80,7 +83,7 @@ describe DockerSync::ProjectConfig do
               'appcode-dummy-sync' => {
                 'src' => "#{fixture_path 'dummy'}/app",
                 'dest' => '/var/www',
-                'sync_strategy' => 'unison',
+                'sync_strategy' => default_sync_strategy,
                 'watch_strategy' => 'dummy'
               }
             }
@@ -101,8 +104,8 @@ describe DockerSync::ProjectConfig do
               'simplest-sync' => {
                 'src' => "#{fixture_path 'simplest'}/app/app",
                 'dest' => '/var/www',
-                'sync_strategy' => 'unison',
-                'watch_strategy' => 'unison'
+                'sync_strategy' => default_sync_strategy,
+                'watch_strategy' => default_watch_strategy,
               }
             }
           })
@@ -122,8 +125,8 @@ describe DockerSync::ProjectConfig do
               'simplest-sync' => {
                 'src' => "#{fixture_path 'simplest'}/app/app",
                 'dest' => '/var/www',
-                'sync_strategy' => 'unison',
-                'watch_strategy' => 'unison'
+                'sync_strategy' => default_sync_strategy,
+                'watch_strategy' => default_watch_strategy,
               }
             }
           })
@@ -141,8 +144,8 @@ describe DockerSync::ProjectConfig do
               'project_root-sync' => {
                 'src' => "#{fixture_path 'project_root'}/app",
                 'dest' => '/var/www',
-                'sync_strategy' => 'unison',
-                'watch_strategy' => 'unison'
+                'sync_strategy' => default_sync_strategy,
+                'watch_strategy' => default_watch_strategy
               }
             }
           })
@@ -166,8 +169,8 @@ describe DockerSync::ProjectConfig do
               'simplest-sync' => {
                 'src' => "#{Dir.pwd}/app",
                 'dest' => '/var/www',
-                'sync_strategy' => 'unison',
-                'watch_strategy' => 'unison'
+                'sync_strategy' => default_sync_strategy,
+                'watch_strategy' => default_watch_strategy
               }
             }
           })
@@ -223,8 +226,8 @@ syncs:
             'config-string-sync' => {
               'src' => "#{Dir.pwd}/foo",
               'dest' => '/foo/bar',
-              'sync_strategy' => 'unison',
-              'watch_strategy' => 'unison'
+              'sync_strategy' => default_sync_strategy,
+              'watch_strategy' => default_watch_strategy
             }
           }
         })
@@ -245,8 +248,8 @@ syncs:
                 'src' => "#{fixture_path 'dynamic-configuration-dotenv'}/app",
                 'dest' => '/var/www',
                 'sync_excludes' => ['ignored_folder', '.ignored_dot_folder' ],
-                'sync_strategy' => 'unison',
-                'watch_strategy' => 'unison'
+                'sync_strategy' => default_sync_strategy,
+                'watch_strategy' => default_watch_strategy
               }
             }
           })
@@ -296,7 +299,15 @@ syncs:
   end
 
   describe '#unison_required?' do
-    it do use_fixture 'simplest' do is_expected.to be_unison_required end end
+    it do
+      use_fixture 'simplest' do
+        if OS.linux?
+          is_expected.not_to be_unison_required
+        else
+          is_expected.to be_unison_required
+        end
+      end
+    end
     it do use_fixture 'rsync' do is_expected.not_to be_unison_required end end
     it do use_fixture 'unison' do is_expected.to be_unison_required end end
   end


### PR DESCRIPTION
to be used by default in linux environment, since docker built in support for mounting volume is good enough and we can use it without relying on rsync or unison..

part of #265 

NOTE: I'm currently using this branch in my local.. give it some time to see if there're any issue, and I'll report back later..