### PR TITLE
raise error instead of failing silently when unison failed to start in time

### DIFF
--- a/lib/docker-sync/sync_strategy/unison.rb
+++ b/lib/docker-sync/sync_strategy/unison.rb
@@ -187,7 +187,7 @@ module Docker_Sync
           stdout, stderr, exit_status = Open3.capture3(cmd)
           break if exit_status == 0
           attempt += 1
-          break if attempt > max_attempt
+          raise 'Failed to start unison container in time, try to increase max_attempt in your configuration. See https://github.com/EugenMayer/docker-sync/wiki/2.-Configuration for more informations' if attempt > max_attempt
           sleep 1
         end
         sync


### PR DESCRIPTION
related to: #217, #291, #320, and several others

even though it doesn't really solve the issue of why the first run is slow, it would help user to understand what they need to do in order to overcome the issue.. and I find it odd to break out the loop silently in both success and failure case.. failure case should be loud so that we know when it does failed..