### PR TITLE
Fix 'private method get_container_name' error in remotelogs watch strategy

### DIFF
--- a/lib/docker-sync/sync_strategy/native_osx.rb
+++ b/lib/docker-sync/sync_strategy/native_osx.rb
@@ -106,6 +106,10 @@ module Docker_Sync
         end
       end
 
+      def get_container_name
+        @sync_name.to_s
+      end
+
       private
 
       def reset_container
@@ -114,10 +118,6 @@ module Docker_Sync
         `docker volume ls -q | grep #{get_volume_name} && docker volume rm #{get_volume_name}`
       end
 
-
-      def get_container_name
-        return "#{@sync_name}"
-      end
 
       def get_volume_name
         return @sync_name


### PR DESCRIPTION
I get the following error when trying to start docker-sync with `native_osx` sync strategy and thus `remotelogs` watch strategy (with current `master`):

```
bin/docker-sync start --foreground
       note:  Starting in foreground mode
          ok  Starting native_osx
          ok  core-sync container still running, restarting unison in container
     command  docker exec core-sync supervisorctl restart unison
          ok  starting initial sync of core-sync
     success  Sync container started
/Users/mike/code/docker-sync/lib/docker-sync/watch_strategy/remotelogs.rb:24:in `run': private method `get_container_name' called for #<Docker_Sync::SyncStrategy::NativeOsx:0x007ff80babce98> (NoMethodError)
	from /Users/mike/code/docker-sync/lib/docker-sync/sync_process.rb:88:in `run'
	from /Users/mike/code/docker-sync/lib/docker-sync/sync_manager.rb:100:in `block in run'
	from /Users/mike/code/docker-sync/lib/docker-sync/sync_manager.rb:99:in `each'
	from /Users/mike/code/docker-sync/lib/docker-sync/sync_manager.rb:99:in `run'
	from /Users/mike/code/docker-sync/tasks/sync/sync.thor:52:in `block in start'
	from /Users/mike/code/docker-sync/tasks/sync/sync.thor:51:in `chdir'
	from /Users/mike/code/docker-sync/tasks/sync/sync.thor:51:in `start'
	from /Library/Ruby/Gems/2.0.0/gems/thor-0.19.4/lib/thor/command.rb:27:in `run'
	from /Library/Ruby/Gems/2.0.0/gems/thor-0.19.4/lib/thor/invocation.rb:126:in `invoke_command'
	from /Library/Ruby/Gems/2.0.0/gems/thor-0.19.4/lib/thor.rb:369:in `dispatch'
	from /Library/Ruby/Gems/2.0.0/gems/thor-0.19.4/lib/thor/base.rb:444:in `start'
	from bin/docker-sync:14:in `<main>'
```

This PR makes `get_container_name` public to prevent this error.