### PR TITLE
Add a development console

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,4 +2,6 @@ source 'https://rubygems.org'
 
 gemspec
 
-gem 'rspec'
+group :test do
+  gem 'rspec'
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -14,13 +14,19 @@ GEM
   remote: https://rubygems.org/
   specs:
     backticks (1.0.0)
+    coderay (1.1.1)
     daemons (1.2.4)
     diff-lcs (1.3)
     docker-compose (1.1.5)
       backticks (~> 1.0)
     dotenv (2.2.1)
     gem_update_checker (0.2.0)
+    method_source (0.8.2)
     os (1.0.0)
+    pry (0.10.4)
+      coderay (~> 1.1.0)
+      method_source (~> 0.8.1)
+      slop (~> 3.4)
     rspec (3.5.0)
       rspec-core (~> 3.5.0)
       rspec-expectations (~> 3.5.0)
@@ -34,6 +40,7 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.5.0)
     rspec-support (3.5.0)
+    slop (3.6.0)
     terminal-notifier (1.6.3)
     thor (0.19.4)
 
@@ -42,6 +49,7 @@ PLATFORMS
 
 DEPENDENCIES
   docker-sync!
+  pry
   rspec
 
 BUNDLED WITH

--- a/bin/console
+++ b/bin/console
@@ -6,5 +6,5 @@ require 'docker-sync'
 # You can add fixtures and/or initialization code here to make experimenting
 # with your gem easier. You can also use a different console, if you like.
 
-require "pry"
+require 'pry'
 Pry.start

--- a/bin/console
+++ b/bin/console
@@ -1,0 +1,10 @@
+#!/usr/bin/env ruby
+
+require 'bundler/setup'
+require 'docker-sync'
+
+# You can add fixtures and/or initialization code here to make experimenting
+# with your gem easier. You can also use a different console, if you like.
+
+require "pry"
+Pry.start

--- a/docker-sync.gemspec
+++ b/docker-sync.gemspec
@@ -4,12 +4,13 @@ Gem::Specification.new do |s|
   s.summary     = 'Docker Sync - Fast and efficient way to sync code to docker-containers'
   s.description = 'Sync your code live to docker-containers without losing any performance on OSX'
   s.authors     = ['Eugen Mayer']
-  s.executables = %w[docker-sync docker-sync-stack docker-sync-daemon]
+  s.executables = %w(docker-sync docker-sync-stack docker-sync-daemon)
   s.email       = 'eugen.mayer@kontextwork.de'
   s.files       = Dir['lib/**/*.rb','tasks/**/*.thor','Thorfile','bin/*','VERSION']
   s.license     = 'GPL'
   s.homepage    = 'https://github.com/EugenMayer/docker_sync'
   s.required_ruby_version = '>= 2.0'
+
   s.add_runtime_dependency 'thor', '~> 0.19', '>= 0.19.0'
   s.add_runtime_dependency 'gem_update_checker', '~> 0.2.0', '>= 0.2.0'
   s.add_runtime_dependency 'docker-compose', '~> 1.0', '>= 1.0.2'
@@ -17,4 +18,6 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'dotenv', '~> 2.1', '>= 2.1.1'
   s.add_runtime_dependency 'daemons', '~> 1.2', '>= 1.2.3'
   s.add_runtime_dependency 'os'
+
+  s.add_development_dependency 'pry'
 end


### PR DESCRIPTION
This adds a development console when running `bin/console` instead of having to type `/usr/bin/env ruby -r bundler/setup -r docker-sync -r pry -e Pry.start` because... you know... it's a lot handier ¯\\\_(ツ)\_/¯

The code is the same as the one generated by running `bundle gem <gem_name>` to create a new gem skeleton.
