### PR TITLE
Fix a typo in operator passed to Hash#key?

### DIFF
--- a/lib/docker-sync/sync_strategy/native_osx.rb
+++ b/lib/docker-sync/sync_strategy/native_osx.rb
@@ -51,7 +51,7 @@ module Docker_Sync
         ignore_strings = expand_ignore_strings
         env['UNISON_EXCLUDES'] = ignore_strings.join(' ')
 
-        if @options.key?['sync_args']
+        if @options.key?('sync_args')
           sync_args = @options['sync_args']
           sync_args = @options['sync_args'].join(' ') if @options['sync_args'].kind_of?(Array)
           env['UNISON_ARGS'] = sync_args


### PR DESCRIPTION
I think this is just a typo introduced in 6102649b4b080dbf0c8a7047a001dd49ede302d2, but it's causing the following error when trying to start any `native_osx` sync from `master`:
```
/Users/mike/code/docker-sync/lib/docker-sync/sync_strategy/native_osx.rb:55:in `key?': wrong number of arguments (0 for 1) (ArgumentError)
	from /Users/mike/code/docker-sync/lib/docker-sync/sync_strategy/native_osx.rb:55:in `start_container'
	from /Users/mike/code/docker-sync/lib/docker-sync/sync_process.rb:107:in `start_container'
	from /Users/mike/code/docker-sync/lib/docker-sync/sync_manager.rb:92:in `block in start_container'
	from /Users/mike/code/docker-sync/lib/docker-sync/sync_manager.rb:91:in `each'
	from /Users/mike/code/docker-sync/lib/docker-sync/sync_manager.rb:91:in `start_container'
	from /Users/mike/code/docker-sync/tasks/sync/sync.thor:163:in `daemonize'
	from /Users/mike/code/docker-sync/tasks/sync/sync.thor:47:in `start'
	from /Library/Ruby/Gems/2.0.0/gems/thor-0.19.4/lib/thor/command.rb:27:in `run'
	from /Library/Ruby/Gems/2.0.0/gems/thor-0.19.4/lib/thor/invocation.rb:126:in `invoke_command'
	from /Library/Ruby/Gems/2.0.0/gems/thor-0.19.4/lib/thor.rb:369:in `dispatch'
	from /Library/Ruby/Gems/2.0.0/gems/thor-0.19.4/lib/thor/base.rb:444:in `start'
	from bin/docker-sync:14:in `<main>'
```