### PR TITLE
set max_attempt option in `@config_syncs` using value from `@config_global`

### DIFF
--- a/lib/docker-sync/sync_manager.rb
+++ b/lib/docker-sync/sync_manager.rb
@@ -40,6 +40,13 @@ module DockerSync
           end
         end
 
+        # set the global max_attempt setting, if the sync-endpoint does not define a own one
+        unless config.key?('max_attempt')
+          if @config_global.key?('max_attempt')
+            @config_syncs[name]['max_attempt'] = @config_global['max_attempt']
+          end
+        end
+
         if @config_syncs[name].key?('dest')
           puts 'Please do no longer use "dest" in your docker-sync.yml configuration - also see https://github.com/EugenMayer/docker-sync/wiki/1.2-Upgrade-Guide#dest-has-been-removed!'
           exit 1

--- a/lib/docker-sync/sync_strategy/unison.rb
+++ b/lib/docker-sync/sync_strategy/unison.rb
@@ -187,7 +187,7 @@ module DockerSync
           stdout, stderr, exit_status = Open3.capture3(cmd)
           break if exit_status == 0
           attempt += 1
-          raise 'Failed to start unison container in time, try to increase max_attempt in your configuration. See https://github.com/EugenMayer/docker-sync/wiki/2.-Configuration for more informations' if attempt > max_attempt
+          raise "Failed to start unison container in time, try to increase max_attempt (currently #{max_attempt}) in your configuration. See https://github.com/EugenMayer/docker-sync/wiki/2.-Configuration for more informations" if attempt > max_attempt
           sleep 1
         end
         sync


### PR DESCRIPTION
This is a missing code to set the `max_attempt` value from `@config_global` into `@config_syncs`

Without this, sync process cannot read the global config value, thus will only using default value set in https://github.com/EugenMayer/docker-sync/blob/master/lib/docker-sync/sync_strategy/unison.rb#L185
