### PR TITLE
Change 'raise' to 'say_status' in native_osx.rb

### DIFF
--- a/lib/docker-sync/sync_strategy/native_osx.rb
+++ b/lib/docker-sync/sync_strategy/native_osx.rb
@@ -45,7 +45,9 @@ module DockerSync
         host_sync_src = @options['src']
         volume_app_sync_name = @sync_name
         env = {}
-        raise 'sync_user is no longer supported, since it ise no needed, use sync_userid only please', :yellow if @options.key?('sync_user')
+        if @options.key?('sync_user')
+          say_status 'warning', 'sync_user is no longer supported, use sync_userid only please', :yellow
+        end
 
         ignore_strings = expand_ignore_strings
         env['UNISON_EXCLUDES'] = ignore_strings.join(' ')

--- a/lib/docker-sync/sync_strategy/native_osx.rb
+++ b/lib/docker-sync/sync_strategy/native_osx.rb
@@ -45,9 +45,7 @@ module DockerSync
         host_sync_src = @options['src']
         volume_app_sync_name = @sync_name
         env = {}
-        if @options.key?('sync_user')
-          say_status 'warning', 'sync_user is no longer supported, use sync_userid only please', :yellow
-        end
+        raise 'sync_user is no longer supported, since it is not needed. Use sync_userid only please' if @options.key?('sync_user')
 
         ignore_strings = expand_ignore_strings
         env['UNISON_EXCLUDES'] = ignore_strings.join(' ')


### PR DESCRIPTION
Currently this causes an error:`'raise': exception class/object expected (TypeError)`

I think perhaps you meant to use `say_status` here