### PR TITLE
Add specs for dependencies

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    docker-sync (0.4.5)
+    docker-sync (0.4.6)
       daemons (~> 1.2, >= 1.2.3)
       docker-compose (~> 1.0, >= 1.0.2)
       dotenv (~> 2.1, >= 2.1.1)

--- a/lib/docker-sync/dependencies.rb
+++ b/lib/docker-sync/dependencies.rb
@@ -2,8 +2,8 @@ require 'mkmf'
 require 'thor/shell'
 
 Dir[
-  File.join(File.dirname(__FILE__), 'dependencies', 'package_managers', 'base.rb'),
-  File.join(File.dirname(__FILE__), 'dependencies', '**', '*.rb')
+  File.join(__dir__, 'dependencies', 'package_managers', 'base.rb'),
+  File.join(__dir__, 'dependencies', '**', '*.rb')
 ].each { |f| require f }
 
 module DockerSync

--- a/lib/docker-sync/dependencies/docker_driver.rb
+++ b/lib/docker-sync/dependencies/docker_driver.rb
@@ -5,7 +5,9 @@ module DockerSync
         def self.docker_for_mac?
           return false unless Environment.mac?
           return @docker_for_mac if defined? @docker_for_mac
-          @docker_for_mac = system('docker info | grep -q "Docker Root Dir: /var/lib/docker" && docker info | grep -q "Operating System: Alpine Linux"')
+          @docker_for_mac =
+            system('docker info | grep -q "Operating System: Alpine Linux"') &&
+            system('docker info | grep -q "Docker Root Dir: /var/lib/docker"')
         end
 
         def self.docker_toolbox?

--- a/lib/docker-sync/dependencies/package_manager.rb
+++ b/lib/docker-sync/dependencies/package_manager.rb
@@ -1,3 +1,5 @@
+require 'forwardable'
+
 module DockerSync
   module Dependencies
     module PackageManager

--- a/lib/docker-sync/dependencies/package_manager.rb
+++ b/lib/docker-sync/dependencies/package_manager.rb
@@ -10,10 +10,14 @@ module DockerSync
 
       def self.package_manager
         return @package_manager if defined? @package_manager
-        return @package_manager = PackageManager::Brew if PackageManager::Brew.available?
-        return @package_manager = PackageManager::Apt  if PackageManager::Apt.available?
-        return @package_manager = PackageManager::Yum  if PackageManager::Yum.available?
+        supported_package_managers.each do |package_manager|
+          return @package_manager = package_manager if package_manager.available?
+        end
         @package_manager = PackageManager::None
+      end
+
+      def self.supported_package_managers
+        ObjectSpace.each_object(::Class).select { |klass| klass < self::Base && klass != self::None }
       end
     end
   end

--- a/lib/docker-sync/dependencies/package_managers/base.rb
+++ b/lib/docker-sync/dependencies/package_managers/base.rb
@@ -1,3 +1,5 @@
+require 'forwardable'
+
 module DockerSync
   module Dependencies
     module PackageManager

--- a/lib/docker-sync/dependencies/package_managers/base.rb
+++ b/lib/docker-sync/dependencies/package_managers/base.rb
@@ -35,11 +35,7 @@ module DockerSync
         end
 
         def perform_installation
-          if defined?(Bundler)
-            Bundler.with_clean_env { system(install_cmd) }
-          else
-            system(install_cmd)
-          end
+          defined?(Bundler) ? Bundler.clean_system(install_cmd) : system(install_cmd)
         end
 
         def install_cmd

--- a/lib/docker-sync/dependencies/package_managers/none.rb
+++ b/lib/docker-sync/dependencies/package_managers/none.rb
@@ -5,7 +5,7 @@ module DockerSync
         NO_PACKAGE_MANAGER_AVAILABLE = 'No package manager was found. Please either install one of those supported (brew, apt, rpm) or install all dependencies manually.'.freeze
 
         def self.available?
-          true
+          @available ||= true
         end
 
         def self.ensure!

--- a/lib/docker-sync/dependencies/unox.rb
+++ b/lib/docker-sync/dependencies/unox.rb
@@ -14,7 +14,7 @@ module DockerSync
       def self.available?
         return @available if defined? @available
         cmd = 'brew list unox &> /dev/null'
-        @available = defined?(Bundler) ? Bundler.with_clean_env { system(cmd) } : system(cmd)
+        @available = defined?(Bundler) ? Bundler.clean_system(cmd) : system(cmd)
       end
 
       def self.ensure!

--- a/lib/docker-sync/dependencies/unox.rb
+++ b/lib/docker-sync/dependencies/unox.rb
@@ -1,3 +1,5 @@
+require 'forwardable'
+
 module DockerSync
   module Dependencies
     module Unox

--- a/lib/docker-sync/dependencies/unox.rb
+++ b/lib/docker-sync/dependencies/unox.rb
@@ -19,16 +19,21 @@ module DockerSync
 
       def self.ensure!
         return if available?
-        cleanup_legacy if File.exist?('/usr/local/bin/unison-fsmonitor')
+        cleanup_non_brew_version!
         PackageManager.install_package('eugenmayer/dockersync/unox')
       end
 
-      def self.cleanup_legacy
+      def self.cleanup_non_brew_version!
+        return unless non_brew_version_installed?
         uninstall_cmd = 'sudo rm -f /usr/local/bin/unison-fsmonitor'
         say_status 'warning', LEGACY_UNOX_WARNING, :yellow
         raise(FAILED_TO_REMOVE_LEGACY_UNOX) unless yes?('Uninstall legacy unison-fsmonitor (unox)? (y/N)')
         say_status 'command', uninstall_cmd, :white
         system(uninstall_cmd)
+      end
+
+      def self.non_brew_version_installed?
+        !available? && File.exist?('/usr/local/bin/unison-fsmonitor')
       end
     end
   end

--- a/spec/helpers/command_mocking_helpers.rb
+++ b/spec/helpers/command_mocking_helpers.rb
@@ -1,0 +1,34 @@
+class CommandExecutionNotAllowed < ::StandardError
+  COMMAND_EXECUTORS = %i(system exec spawn `).freeze
+
+  attr_reader :method_name, :args
+  def initialize(method_name, *args)
+    @method_name = method_name
+    @args        = args
+  end
+
+  def to_s
+    "Command execution is not allowed. Please stub the following call: #{method_name}(#{args.map(&:inspect).join(', ')})"
+  end
+end
+
+RSpec.configure do |config|
+  config.before(:each) do
+    CommandExecutionNotAllowed::COMMAND_EXECUTORS.each do |command_executor|
+      allow_any_instance_of(Object).to receive(command_executor).and_wrap_original do |method, *args|
+        raise CommandExecutionNotAllowed.new(method.name, *args)
+      end
+      allow(Kernel).to receive(command_executor).and_wrap_original do |method, *args|
+        raise CommandExecutionNotAllowed.new(method.name, *args)
+      end
+    end
+  end
+end
+
+RSpec::Matchers.define :execute_nothing do |_expected|
+  match do |_actual|
+    CommandExecutionNotAllowed::COMMAND_EXECUTORS.each do |command_executor|
+      expect(Kernel).to_not receive(command_executor)
+    end
+  end
+end

--- a/spec/helpers/ignore_errors_helpers.rb
+++ b/spec/helpers/ignore_errors_helpers.rb
@@ -1,0 +1,9 @@
+module IgnoreErrorsHelpers
+  def ignore_errors(*errors)
+    yield
+  rescue *errors => ex
+    puts "warning: #{ex.class} ignored"
+  end
+end
+
+RSpec.configuration.include(IgnoreErrorsHelpers)

--- a/spec/helpers/ignore_errors_helpers.rb
+++ b/spec/helpers/ignore_errors_helpers.rb
@@ -1,9 +1,0 @@
-module IgnoreErrorsHelpers
-  def ignore_errors(*errors)
-    yield
-  rescue *errors => ex
-    puts "warning: #{ex.class} ignored"
-  end
-end
-
-RSpec.configuration.include(IgnoreErrorsHelpers)

--- a/spec/helpers/raise_error_helpers.rb
+++ b/spec/helpers/raise_error_helpers.rb
@@ -1,0 +1,12 @@
+module RaiseErrorHelpers
+  def is_expected_to_raise_error(*args)
+    expect { subject }.to raise_error(*args)
+  end
+
+  def is_expected_not_to_raise_error
+    expect { subject }.not_to raise_error
+  end
+  alias is_expected_to_not_raise_error is_expected_not_to_raise_error
+end
+
+RSpec.configuration.include(RaiseErrorHelpers)

--- a/spec/lib/docker-sync/dependencies/docker_driver_spec.rb
+++ b/spec/lib/docker-sync/dependencies/docker_driver_spec.rb
@@ -1,0 +1,72 @@
+require 'spec_helper'
+
+RSpec.describe DockerSync::Dependencies::Docker::Driver do
+  describe '.docker_for_mac?' do
+    let(:mac?) { true }
+
+    before do
+      allow(DockerSync::Environment).to receive(:mac?).and_return(mac?)
+      allow(described_class).to receive(:system).and_return(true)
+      described_class.remove_instance_variable(:@docker_for_mac) if described_class.instance_variable_defined? :@docker_for_mac
+    end
+
+    subject { described_class.docker_for_mac? }
+
+    context 'when not running on a Macintosh' do
+      let(:mac?) { false }
+      it { is_expected.to be false }
+      it { is_expected.to execute_nothing }
+    end
+
+    it 'checks if Docker is running in Alpine Linux (Hyperkit)' do
+      subject
+      expect(described_class).to have_received(:system).with('docker info | grep -q "Operating System: Alpine Linux"')
+    end
+
+    it 'checks if Docker is running from /var/lib/docker' do
+      subject
+      expect(described_class).to have_received(:system).with('docker info | grep -q "Docker Root Dir: /var/lib/docker"')
+    end
+
+    it 'is memoized' do
+      expect { 2.times { described_class.docker_for_mac? } }.to change { described_class.instance_variable_defined?(:@docker_for_mac) }
+      expect(described_class).to have_received(:system).exactly(:twice)
+    end
+  end
+
+  describe '.docker_toolbox?' do
+    let(:mac?)                      { true }
+    let(:docker_machine_available?) { true }
+
+    before do
+      allow(DockerSync::Environment).to receive(:mac?).and_return(mac?)
+      allow(described_class).to receive(:find_executable0).with('docker-machine').and_return(docker_machine_available?)
+      allow(described_class).to receive(:system).and_return(true)
+      described_class.remove_instance_variable(:@docker_toolbox) if described_class.instance_variable_defined? :@docker_toolbox
+    end
+
+    subject { described_class.docker_toolbox? }
+
+    context 'when not running on a Macintosh' do
+      let(:mac?) { false }
+      it { is_expected.to be false }
+      it { is_expected.to execute_nothing }
+    end
+
+    context 'when docker-machine is not available' do
+      let(:docker_machine_available?) { false }
+      it { is_expected.to be false }
+      it { is_expected.to execute_nothing }
+    end
+
+    it 'checks if Docker is running in Boot2Docker' do
+      subject
+      expect(described_class).to have_received(:system).with('docker info | grep -q "Operating System: Boot2Docker"')
+    end
+
+    it 'is memoized' do
+      expect { 2.times { described_class.docker_toolbox? } }.to change { described_class.instance_variable_defined?(:@docker_toolbox) }
+      expect(described_class).to have_received(:system).exactly(:once)
+    end
+  end
+end

--- a/spec/lib/docker-sync/dependencies/docker_spec.rb
+++ b/spec/lib/docker-sync/dependencies/docker_spec.rb
@@ -1,0 +1,51 @@
+require 'spec_helper'
+require 'pry'
+
+RSpec.describe DockerSync::Dependencies::Docker do
+  it_behaves_like 'a dependency'
+  it_behaves_like 'a binary-checking dependency', 'docker'
+
+  describe '.running?' do
+    before do
+      described_class.remove_instance_variable(:@running) if described_class.instance_variable_defined? :@running
+    end
+
+    subject { described_class.running? }
+
+    context 'when `docker ps` succeeds' do
+      before { expect(described_class).to receive(:system).with(/^docker ps/).and_return(true) }
+      it { is_expected.to be true }
+    end
+
+    context 'when `docker ps` errors' do
+      before { expect(described_class).to receive(:system).with(/^docker ps/).and_return(false) }
+      it { is_expected.to be false }
+    end
+  end
+
+  describe 'ensure!' do
+    let(:available?) { true }
+    let(:running?)   { true }
+
+    before do
+      allow(described_class).to receive(:available?).and_return(available?)
+      allow(described_class).to receive(:running?).and_return(running?)
+    end
+
+    subject { described_class.ensure! }
+
+    context 'when Docker is both available and running' do
+      it { is_expected_not_to_raise_error }
+    end
+
+    context 'when Docker is not available' do
+      let(:available?) { false }
+      it { is_expected_to_raise_error RuntimeError }
+    end
+
+    context 'when Docker is not running' do
+      let(:running?) { false }
+      it { is_expected_to_raise_error RuntimeError }
+    end
+  end
+end

--- a/spec/lib/docker-sync/dependencies/fswatch_spec.rb
+++ b/spec/lib/docker-sync/dependencies/fswatch_spec.rb
@@ -1,0 +1,7 @@
+require 'spec_helper'
+
+RSpec.describe DockerSync::Dependencies::Fswatch do
+  it_behaves_like 'a dependency'
+  it_behaves_like 'a binary-checking dependency', 'fswatch'
+  it_behaves_like 'a binary-installing dependency', 'fswatch'
+end

--- a/spec/lib/docker-sync/dependencies/package_manager_spec.rb
+++ b/spec/lib/docker-sync/dependencies/package_manager_spec.rb
@@ -1,0 +1,40 @@
+require 'spec_helper'
+
+RSpec.describe DockerSync::Dependencies::PackageManager do
+  describe '.package_manager' do
+    before do
+      described_class.remove_instance_variable :@package_manager if described_class.instance_variable_defined? :@package_manager
+      described_class.supported_package_managers.each do |package_manager|
+        allow(package_manager).to receive(:available?).and_return(false)
+      end
+    end
+
+    subject { described_class.package_manager }
+
+    context 'when a package manager is available' do
+      let(:available_package_manager) { described_class.supported_package_managers.sample }
+      before { allow(available_package_manager).to receive(:available?).and_return(true) }
+      it { is_expected.to eq available_package_manager }
+    end
+
+    context 'when no package manager is available' do
+      it { is_expected.to eq described_class::None }
+    end
+
+    it 'is memoized' do
+      expect { subject }.to change { described_class.instance_variable_defined? :@package_manager }.from(false).to(true)
+    end
+  end
+
+  describe '.supported_package_managers' do
+    subject { described_class.supported_package_managers }
+
+    it 'returns all supported package managers' do
+      expect(subject).to match_array [
+        DockerSync::Dependencies::PackageManager::Brew,
+        DockerSync::Dependencies::PackageManager::Apt,
+        DockerSync::Dependencies::PackageManager::Yum
+      ]
+    end
+  end
+end

--- a/spec/lib/docker-sync/dependencies/package_managers/apt_spec.rb
+++ b/spec/lib/docker-sync/dependencies/package_managers/apt_spec.rb
@@ -1,0 +1,7 @@
+require 'spec_helper'
+
+RSpec.describe DockerSync::Dependencies::PackageManager::Apt do
+  it_behaves_like 'a dependency'
+  it_behaves_like 'a binary-checking dependency', 'apt-get'
+  it_behaves_like 'a package manager'
+end

--- a/spec/lib/docker-sync/dependencies/package_managers/brew_spec.rb
+++ b/spec/lib/docker-sync/dependencies/package_managers/brew_spec.rb
@@ -1,0 +1,7 @@
+require 'spec_helper'
+
+RSpec.describe DockerSync::Dependencies::PackageManager::Brew do
+  it_behaves_like 'a dependency'
+  it_behaves_like 'a binary-checking dependency', 'brew'
+  it_behaves_like 'a package manager'
+end

--- a/spec/lib/docker-sync/dependencies/package_managers/none_spec.rb
+++ b/spec/lib/docker-sync/dependencies/package_managers/none_spec.rb
@@ -14,33 +14,20 @@ RSpec.describe DockerSync::Dependencies::PackageManager::None do
   end
 
   describe '.install_package(package_name)' do
-    let(:user_confirmed?) { true }
-    let(:package_name)    { 'some-package' }
+    let(:package_name) { 'some-package' }
 
     before do
       allow(described_class).to receive(:ensure!)
       allow_any_instance_of(Thor::Shell::Color).to receive_messages(
         say_status: nil,
-        yes?: user_confirmed?
+        yes?: true
       )
     end
 
     subject { described_class.install_package(package_name) }
 
-    it 'asks for user confirmation' do
-      expect_any_instance_of(Thor::Shell::Color).to receive(:yes?)
-      ignore_errors(RuntimeError) { subject }
+    it 'tells user to install any of the supported package managers' do
+      expect { subject }.to raise_error(described_class::NO_PACKAGE_MANAGER_AVAILABLE)
     end
-
-    context 'when user confirmed installation' do
-      let(:user_confirmed?) { true }
-      it { is_expected_to_raise_error RuntimeError }
-    end
-
-    context 'when user canceled installation' do
-      let(:user_confirmed?) { false }
-      it { is_expected_to_raise_error RuntimeError }
-    end
-
   end
 end

--- a/spec/lib/docker-sync/dependencies/package_managers/none_spec.rb
+++ b/spec/lib/docker-sync/dependencies/package_managers/none_spec.rb
@@ -1,0 +1,46 @@
+require 'spec_helper'
+
+RSpec.describe DockerSync::Dependencies::PackageManager::None do
+  it_behaves_like 'a dependency'
+
+  describe '.available?' do
+    subject { described_class.available? }
+    it { is_expected.to be true }
+  end
+
+  describe '.ensure!' do
+    subject { described_class.ensure! }
+    it { is_expected.to execute_nothing }
+  end
+
+  describe '.install_package(package_name)' do
+    let(:user_confirmed?) { true }
+    let(:package_name)    { 'some-package' }
+
+    before do
+      allow(described_class).to receive(:ensure!)
+      allow_any_instance_of(Thor::Shell::Color).to receive_messages(
+        say_status: nil,
+        yes?: user_confirmed?
+      )
+    end
+
+    subject { described_class.install_package(package_name) }
+
+    it 'asks for user confirmation' do
+      expect_any_instance_of(Thor::Shell::Color).to receive(:yes?)
+      ignore_errors(RuntimeError) { subject }
+    end
+
+    context 'when user confirmed installation' do
+      let(:user_confirmed?) { true }
+      it { is_expected_to_raise_error RuntimeError }
+    end
+
+    context 'when user canceled installation' do
+      let(:user_confirmed?) { false }
+      it { is_expected_to_raise_error RuntimeError }
+    end
+
+  end
+end

--- a/spec/lib/docker-sync/dependencies/package_managers/yum_spec.rb
+++ b/spec/lib/docker-sync/dependencies/package_managers/yum_spec.rb
@@ -1,0 +1,7 @@
+require 'spec_helper'
+
+RSpec.describe DockerSync::Dependencies::PackageManager::Yum do
+  it_behaves_like 'a dependency'
+  it_behaves_like 'a binary-checking dependency', 'yum'
+  it_behaves_like 'a package manager'
+end

--- a/spec/lib/docker-sync/dependencies/rsync_spec.rb
+++ b/spec/lib/docker-sync/dependencies/rsync_spec.rb
@@ -1,0 +1,7 @@
+require 'spec_helper'
+
+RSpec.describe DockerSync::Dependencies::Rsync do
+  it_behaves_like 'a dependency'
+  it_behaves_like 'a binary-checking dependency', 'rsync'
+  it_behaves_like 'a binary-installing dependency', 'rsync'
+end

--- a/spec/lib/docker-sync/dependencies/unison_spec.rb
+++ b/spec/lib/docker-sync/dependencies/unison_spec.rb
@@ -1,0 +1,38 @@
+require 'spec_helper'
+
+RSpec.describe DockerSync::Dependencies::Unison do
+  before do
+    allow(DockerSync::Dependencies::PackageManager).to receive(:install_package)
+    allow(DockerSync::Dependencies::Unox).to receive(:ensure!)
+  end
+
+  it_behaves_like 'a dependency'
+  it_behaves_like 'a binary-checking dependency', 'unison'
+  it_behaves_like 'a binary-installing dependency', 'unison'
+
+  describe '.ensure!' do
+    before do
+      allow(described_class).to receive(:available?).and_return(available?)
+    end
+
+    subject { described_class.ensure! }
+
+    context 'when unison is available' do
+      let(:available?) { true }
+
+      it 'ensures that Unox is available too' do
+        subject
+        expect(DockerSync::Dependencies::Unox).to have_received(:ensure!)
+      end
+    end
+
+    context 'when unison is not available' do
+      let(:available?) { false }
+
+      it 'ensures that Unox is available too' do
+        subject
+        expect(DockerSync::Dependencies::Unox).to have_received(:ensure!)
+      end
+    end
+  end
+end

--- a/spec/lib/docker-sync/dependencies/unox_spec.rb
+++ b/spec/lib/docker-sync/dependencies/unox_spec.rb
@@ -1,0 +1,126 @@
+require 'spec_helper'
+
+RSpec.describe DockerSync::Dependencies::Unox do
+  before do
+    allow(described_class).to receive(:system).with(/^brew list unox/)
+    allow(Bundler).to receive(:clean_system).with(/^brew list unox/)
+  end
+
+  it_behaves_like 'a dependency'
+
+  describe '.available?' do
+    before do
+      described_class.remove_instance_variable(:@available) if described_class.instance_variable_defined? :@available
+    end
+
+    subject { described_class.available? }
+
+    context 'when Bundler is not used' do
+      before { hide_const("Bundler") if defined? Bundler }
+
+      context "when Unox was installed using brew" do
+        before { allow(described_class).to receive(:system).with(/^brew list unox/).and_return(true) }
+        it { is_expected.to be true }
+      end
+
+      context "when Unox was not installed using brew" do
+        before { allow(described_class).to receive(:system).with(/^brew list unox/).and_return(false) }
+        it { is_expected.to be false }
+      end
+    end
+
+    context 'when Bundler is used' do
+      before { stub_const("Bundler") unless defined? Bundler }
+
+      it 'performs brew search in clean env (outside of Bundler env)' do
+        subject
+        expect(Bundler).to have_received(:clean_system).with(/^brew list unox/)
+      end
+    end
+  end
+
+  describe '.ensure!' do
+    subject { described_class.ensure! }
+
+    context 'when it is already available' do
+      before { allow(described_class).to receive(:available?).and_return(true) }
+      it { is_expected_to_not_raise_error }
+    end
+
+    context 'when it is not available' do
+      before do
+        allow(described_class).to receive(:available?).and_return(false)
+        allow(DockerSync::Dependencies::PackageManager).to receive(:install_package)
+      end
+
+      it 'eventually cleans up any non-brew version installed' do
+        expect(described_class).to receive(:cleanup_non_brew_version!)
+        subject
+      end
+
+      it 'tries to install it' do
+        subject
+        expect(DockerSync::Dependencies::PackageManager).to have_received(:install_package).with('eugenmayer/dockersync/unox')
+      end
+    end
+  end
+
+  describe 'cleanup_non_brew_version!' do
+    before do
+      allow_any_instance_of(Thor::Shell::Color).to receive(:say_status)
+      allow(described_class).to receive(:system)
+    end
+
+    subject { described_class.cleanup_non_brew_version! }
+
+    context 'when a (legacy) non-brew version is not installed' do
+      before { allow(described_class).to receive(:non_brew_version_installed?).and_return(false) }
+
+      it 'does nothing' do
+        subject
+        expect(described_class).to_not have_received(:system)
+      end
+    end
+
+    context 'when a (legacy) non-brew version is installed' do
+      before { allow(described_class).to receive(:non_brew_version_installed?).and_return(true) }
+
+      context 'when user confirms cleanup' do
+        before { allow_any_instance_of(Thor::Shell::Color).to receive(:yes?).and_return(true) }
+
+        it 'deletes the binary' do
+          subject
+          expect(described_class).to have_received(:system).with('sudo rm -f /usr/local/bin/unison-fsmonitor')
+        end
+      end
+
+      context 'when user cancels cleanup' do
+        before { allow_any_instance_of(Thor::Shell::Color).to receive(:yes?).and_return(false) }
+        it { is_expected_to_raise_error RuntimeError }
+      end
+    end
+  end
+
+  describe '.non_brew_version_installed?' do
+    subject { described_class.non_brew_version_installed? }
+
+    context 'when brew version is available' do
+      before { expect(described_class).to receive(:available?).and_return(true) }
+      it { is_expected.to be false }
+    end
+
+    context 'when brew version is not available' do
+      before { expect(described_class).to receive(:available?).and_return(false) }
+
+      context 'when `/usr/local/bin/unison-fsmonitor` exists' do
+        before { allow(File).to receive(:exist?).with('/usr/local/bin/unison-fsmonitor').and_return(true) }
+        it { is_expected.to be true }
+      end
+
+      context 'when `/usr/local/bin/unison-fsmonitor` does not exist' do
+        before { allow(File).to receive(:exist?).with('/usr/local/bin/unison-fsmonitor').and_return(false) }
+        it { is_expected.to be false }
+      end
+    end
+  end
+end

--- a/spec/lib/docker-sync/dependencies_spec.rb
+++ b/spec/lib/docker-sync/dependencies_spec.rb
@@ -1,0 +1,111 @@
+require 'spec_helper'
+
+RSpec.describe DockerSync::Dependencies do
+  let(:config) { double(:config, unison_required?: false, rsync_required?: false, fswatch_required?: false) }
+
+  describe '.ensure_all!(config)' do
+    let(:mac?)   { false }
+    let(:linux?) { false }
+
+    before do
+      allow(DockerSync::Environment).to receive(:mac?).and_return(mac?)
+      allow(DockerSync::Environment).to receive(:linux?).and_return(linux?)
+      allow(described_class).to receive(:ensure_all_for_mac!)
+      allow(described_class).to receive(:ensure_all_for_linux!)
+    end
+
+    subject { described_class.ensure_all!(config) }
+
+    context 'when running on a Macintosh' do
+      let(:mac?) { true }
+
+      it 'delegates to `ensure_all_for_mac!` with given config' do
+        subject
+        expect(described_class).to have_received(:ensure_all_for_mac!).with(config)
+      end
+    end
+
+    context 'when running on Linux' do
+      let(:linux?) { true }
+
+      it 'delegates to `ensure_all_for_mac!` with given config' do
+        subject
+        expect(described_class).to have_received(:ensure_all_for_linux!).with(config)
+      end
+    end
+
+    context 'when running on another OS' do
+      it 'raises an error' do
+        expect { subject }.to raise_error(RuntimeError)
+      end
+    end
+  end
+
+  describe '.ensure_all_for_linux!(_config)' do
+    before do
+      allow(described_class::Docker).to receive(:ensure!)
+    end
+
+    subject { described_class.ensure_all_for_linux!(config) }
+
+    it 'ensures that Docker is available' do
+      subject
+      expect(described_class::Docker).to have_received(:ensure!)
+    end
+  end
+
+  describe '.ensure_all_for_mac!(config)' do
+    before do
+      allow(described_class::PackageManager).to receive(:ensure!)
+      allow(described_class::Docker).to receive(:ensure!)
+    end
+
+    subject { described_class.ensure_all_for_mac!(config) }
+
+    it 'ensures that a package manager is available' do
+      subject
+      expect(described_class::PackageManager).to have_received(:ensure!)
+    end
+
+    it 'ensures that Docker is available' do
+      subject
+      expect(described_class::Docker).to have_received(:ensure!)
+    end
+
+    context "when Unison is required by given `config`" do
+      before do
+        allow(config).to receive(:unison_required?).and_return(true)
+        allow(described_class::Unison).to receive(:ensure!)
+      end
+
+      it 'ensures that Unison is available' do
+        subject
+        expect(described_class::Unison).to have_received(:ensure!)
+      end
+    end
+
+    context "when Rsync is required by given `config`" do
+      before do
+        allow(config).to receive(:rsync_required?).and_return(true)
+        allow(described_class::Rsync).to receive(:ensure!)
+      end
+
+      it 'ensures that Rsync is available' do
+        subject
+        expect(described_class::Rsync).to have_received(:ensure!)
+      end
+    end
+
+    context "when FSWatch is required by given `config`" do
+      before do
+        allow(config).to receive(:fswatch_required?).and_return(true)
+        allow(described_class::Fswatch).to receive(:ensure!)
+      end
+
+      it 'ensures that FSWatch is available' do
+        subject
+        expect(described_class::Fswatch).to have_received(:ensure!)
+      end
+    end
+  end
+end

--- a/spec/shared_examples/dependencies_shared_example.rb
+++ b/spec/shared_examples/dependencies_shared_example.rb
@@ -1,0 +1,67 @@
+require 'spec_helper'
+
+RSpec.shared_examples 'a dependency' do
+  before do
+    described_class.remove_instance_variable(:@available) if described_class.instance_variable_defined? :@available
+  end
+
+  it 'implements `.available?`' do
+    expect(described_class).to respond_to :available?
+  end
+
+  it 'memoizes availability' do
+    expect { described_class.available? }.to change { described_class.instance_variable_defined? :@available }.from(false).to(true)
+  end
+
+  it 'implements `.ensure!`' do
+    expect(described_class).to respond_to :available?
+  end
+end
+
+RSpec.shared_examples 'a binary-checking dependency' do |binary|
+  describe '.available?' do
+    let(:binary_exists?) { true }
+
+    before do
+      described_class.remove_instance_variable(:@available) if described_class.instance_variable_defined? :@available
+      allow(described_class).to receive(:find_executable0).with(binary).and_return(binary_exists?)
+    end
+
+    subject { described_class.available? }
+
+    context "when `#{binary}` binary is found in $PATH" do
+      it { is_expected.to be true }
+    end
+
+    context "when `#{binary}` binary is not found in $PATH" do
+      let(:binary_exists?) { false }
+      it { is_expected.to be false }
+    end
+  end
+end
+
+RSpec.shared_examples 'a binary-installing dependency' do |binary|
+  describe '.ensure!' do
+    let(:available?) { true }
+
+    before do
+      allow(described_class).to receive(:available?).and_return(available?)
+      allow(DockerSync::Dependencies::PackageManager).to receive(:install_package)
+    end
+
+    subject { described_class.ensure! }
+
+    context "when `#{binary}` is available" do
+      it { is_expected_not_to_raise_error }
+    end
+
+    context "when `#{binary}` is not available" do
+      let(:available?) { false }
+
+      it 'tries to install it' do
+        subject
+        expect(DockerSync::Dependencies::PackageManager).to have_received(:install_package).with(binary)
+      end
+    end
+  end
+end

--- a/spec/shared_examples/dependencies_shared_example.rb
+++ b/spec/shared_examples/dependencies_shared_example.rb
@@ -14,7 +14,7 @@ RSpec.shared_examples 'a dependency' do
   end
 
   it 'implements `.ensure!`' do
-    expect(described_class).to respond_to :available?
+    expect(described_class).to respond_to :ensure!
   end
 end
 

--- a/spec/shared_examples/package_managers_shared_examples.rb
+++ b/spec/shared_examples/package_managers_shared_examples.rb
@@ -1,0 +1,48 @@
+require 'spec_helper'
+
+RSpec.shared_examples 'a package manager' do
+  it 'defines the command used to install a package' do
+    expect(described_class.private_instance_methods(false)).to include :install_cmd
+  end
+
+  describe '.install_package(package_name)' do
+    let(:user_confirmed?) { true }
+    let(:package_name)    { 'some-package' }
+
+    before do
+      allow(described_class).to receive(:ensure!)
+      allow(Kernel).to receive(:system).and_return(true)
+      allow_any_instance_of(Thor::Shell::Color).to receive_messages(
+        say_status: nil,
+        yes?: user_confirmed?
+      )
+    end
+
+    subject { described_class.install_package(package_name) }
+
+    it 'ensures this package manager is available' do
+      subject
+      expect(described_class).to have_received(:ensure!)
+    end
+
+    it 'asks for user confirmation' do
+      expect_any_instance_of(Thor::Shell::Color).to receive(:yes?)
+      subject
+    end
+
+    context 'when user confirmed installation' do
+      let(:user_confirmed?) { true }
+      let(:install_command) { described_class.new(package_name).send(:install_cmd) }
+
+      it 'executes the package installation command' do
+        subject
+        expect(Kernel).to have_received(:system).with(install_command)
+      end
+    end
+
+    context 'when user canceled installation' do
+      let(:user_confirmed?) { false }
+      it { is_expected_to_raise_error RuntimeError }
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -104,6 +104,7 @@ RSpec.configure do |config|
 =end
 end
 
-Dir[File.join(__dir__, 'helpers', '**', '*.rb')].each do |helper|
-  require helper
-end
+Dir[
+  File.join(__dir__, 'helpers', '**', '*.rb'),
+  File.join(__dir__, 'shared_examples', '**', '*.rb')
+].each { |f| require f }


### PR DESCRIPTION
This PR adds specs (using RSpec) for dependencies-related code from #391 (including package managers abstraction layer).

Part of #23

My proposal for next quality-related steps:

0. Fix existing specs (for `GlobalConfig` and `ProjectConfig`)
1. Configure Travis (including automatic PR check and badge ✨ ) (only @EugenMayer can do that)
2. Configure CodeClimate (with Rubocop engine?) for code quality and code coverage monitoring
3. Implement options to bypass network-mandatory steps (`--[no-]auto-install`, `--[no-]auto-update`, `--[no-]auto-upgrade`, ...) or mock those in the test suite
4. Add integration tests (RSpec-Bash ? InSpec ? both?)
5. Document specs requirements for PRs in a `CONTRIBUTING.md` file / `Contributing` section in `README.md` file and enforce it by rejecting any PR that:
    * don't pass tests
    * decrease test coverage
    * decrease code qualitty
