### PR TITLE
Fix bug with unison with spaces in the "prefer" option

### DIFF
--- a/lib/docker-sync/sync_strategy/unison.rb
+++ b/lib/docker-sync/sync_strategy/unison.rb
@@ -134,9 +134,9 @@ module DockerSync
       def sync_prefer
         case @options.fetch('sync_prefer', 'default')
           when 'default' then "-prefer '#{@options['src']}' -copyonconflict" # thats our default, if nothing is set
-          when 'src' then "-prefer #{@options['src']}"
-          when 'dest' then "-prefer #{@options['dest']}"
-          else "-prefer #{@options['sync_prefer']}"
+          when 'src' then "-prefer '#{@options['src']}'"
+          when 'dest' then "-prefer '#{@options['dest']}'"
+          else "-prefer '#{@options['sync_prefer']}'"
         end
       end
 


### PR DESCRIPTION
I encountered this issue when I tried to start `docker-sync` from a repository in my iCloud drive.

The broken command was:

```
unison -ignore='Path .*.swp' -ignore='Path */.*.swp' -ignore='Path .git' -ignore='Path .idea' -ignore='Path .awcache' -ignore='Path .happypack' -ignore='Path assets/[0-9a-f]*' -ignore='Path di-container.php' -ignore='Path docker/mysql' -ignore='Path protected/lib/Kounta/Config/cache/*.php' -ignore='Path protected/runtime' '/Users/elliot/Library/Mobile Documents/com~apple~CloudDocs/Development/github.com/kounta/kounta/' -auto -batch -prefer /Users/elliot/Library/Mobile Documents/com~apple~CloudDocs/Development/github.com/kounta/kounta/ socket://127.0.0.1:32769
```

Correctly escaping the `-prefer` fixed the issue.

---

On a side note it is possible that even `'` would be allowed in a path. All bash values should be escaped correctly. It would have to be replaced in a lot of places.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eugenmayer/docker-sync/426)
<!-- Reviewable:end -->
