### PR TITLE
Print the current sync time along with the watcher's output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .idea/workspace.xml
+*.sw*
 # Created by .ignore support plugin (hsz.mobi)
 ### Ruby template
 *.gem

--- a/lib/docker-sync/execution.rb
+++ b/lib/docker-sync/execution.rb
@@ -2,55 +2,31 @@ require 'open3'
 require 'thor/shell'
 
 module Execution
-
   Thread.abort_on_exception = true
 
-  def threadexec(command, prefix = nil, color = nil)
-
-    if prefix.nil?
-      # TODO: probably pick the command name without args
-      prefix = 'unknown'
-    end
-
-    if color.nil?
-      color = :cyan
-    end
-
-    Thread.new {
+  def thread_exec(command, prefix = 'unknown', color = :cyan)
+    Thread.new do
       Open3.popen3(command) do |_, stdout, stderr, _|
-
         # noinspection RubyAssignmentExpressionInConditionalInspection
         while line_out = stdout.gets
-          say_status prefix, line_out, color
+          say_status with_time(prefix), line_out, color
         end
 
         # noinspection RubyAssignmentExpressionInConditionalInspection
         while line_err = stderr.gets
-          say_status prefix, line_err, :red
+          say_status with_time(prefix), line_err, :red
         end
-
       end
-    }
-
+    end
   end
 
   # unison doesn't work when ran in a new thread
   # this functions creates a full new process instead
-  def forkexec(command, prefix = nil, color = nil)
-
-    if prefix.nil?
-      # TODO: probably pick the command name without args
-      prefix = 'unknown'
-    end
-
-    if color.nil?
-      color = :cyan
-    end
-
-    Process.fork  {
-      `#{command}` || raise(command + ' failed')
-    }
-
+  def fork_exec(command, _prefix = 'unknown', _color = :cyan)
+    Process.fork  { `#{command}` || raise(command + ' failed') }
   end
 
+  def with_time(prefix)
+    "[#{Time.now}] #{prefix}"
+  end
 end

--- a/lib/docker-sync/sync_strategy/unison.rb
+++ b/lib/docker-sync/sync_strategy/unison.rb
@@ -66,7 +66,7 @@ module DockerSync
         cmd = cmd + 'unison ' + args.join(' ')
 
         say_status 'command', cmd, :white if @options['verbose']
-        forkexec(cmd, "Sync #{@sync_name}", :blue)
+        fork_exec(cmd, "Sync #{@sync_name}", :blue)
       end
 
       def sync

--- a/lib/docker-sync/watch_strategy/fswatch.rb
+++ b/lib/docker-sync/watch_strategy/fswatch.rb
@@ -42,7 +42,7 @@ module DockerSync
         say_status 'command', cmd, :white if @options['verbose']
 
         # run a thread here, since it is blocking
-        @watch_thread = threadexec(cmd, "Sync #{@sync_name}", :blue)
+        @watch_thread = thread_exec(cmd, "Sync #{@sync_name}", :blue)
       end
 
       def watch_options

--- a/lib/docker-sync/watch_strategy/remotelogs.rb
+++ b/lib/docker-sync/watch_strategy/remotelogs.rb
@@ -23,7 +23,7 @@ module DockerSync
       def run
         say_status 'success', "Showing unison logs from your sync container: #{@unison.get_container_name}", :green
         cmd = "docker exec #{@unison.get_container_name} tail -F /tmp/unison.log"
-        @watch_thread = threadexec(cmd, 'Sync Log:')
+        @watch_thread = thread_exec(cmd, 'Sync Log:')
       end
 
       def stop


### PR DESCRIPTION
**Use case:** when I'm not sure whether the last change synced properly I usually check the `docker-sync` log in order to see what actually happened, but it turns out that having no time reference doesn't help that much:

```
$ docker-sync logs -f
...
     success  Starting to watch /Users/tiagopog/Dev/ruby/my_awesome_project - Press CTRL-C to stop
Sync web-sync            ok  Synced /Users/tiagopog/Dev/ruby/my_awesome_project
Sync web-sync            ok  Synced /Users/tiagopog/Dev/ruby/my_awesome_project
Sync web-sync            ok  Synced /Users/tiagopog/Dev/ruby/my_awesome_project
```

Now prepending the sync time in the output string makes really easier to figure out whether something was synced:

```
$ docker-sync logs -f
...
     success  Starting to watch /Users/tiagopog/Dev/ruby/my_awesome_project - Press CTRL-C to stop
[2017-07-02 03:44:04 -0300] Sync web-sync            ok  Synced /Users/tiagopog/Dev/ruby/my_awesome_project
[2017-07-02 03:45:15 -0300] Sync web-sync            ok  Synced /Users/tiagopog/Dev/ruby/my_awesome_project
[2017-07-02 03:47:21 -0300] Sync web-sync            ok  Synced /Users/tiagopog/Dev/ruby/my_awesome_project
```

I hope this is helpful and thanks for this awesome project.