### PR TITLE
Added support for --sync-prefix to add to sync_name

### DIFF
--- a/lib/docker-sync/sync_manager.rb
+++ b/lib/docker-sync/sync_manager.rb
@@ -64,44 +64,45 @@ module DockerSync
       end
     end
 
-    def init_sync_processes(sync_name = nil)
+    def init_sync_processes(sync_name = nil, sync_prefix = '')
       return if @sync_processes.size != 0
+
       if sync_name.nil?
         @config_syncs.each { |name, sync_configuration|
-          @sync_processes.push(create_sync(name, sync_configuration))
+          @sync_processes.push(create_sync(sync_prefix + name, sync_configuration))
         }
       else
         unless @config_syncs.key?(sync_name)
           raise("Could not find sync configuration with name #{sync_name}")
         end
-        @sync_processes.push(create_sync(sync_name, @config_syncs[sync_name]))
+        @sync_processes.push(create_sync(sync_prefix + sync_name, @config_syncs[sync_name]))
       end
     end
 
 
-    def clean(sync_name = nil)
-      init_sync_processes(sync_name)
+    def clean(sync_name = nil, sync_prefix = '')
+      init_sync_processes(sync_name, sync_prefix)
       @sync_processes.each { |sync_process|
         sync_process.clean
       }
     end
 
-    def sync(sync_name = nil)
-      init_sync_processes(sync_name)
+    def sync(sync_name = nil, sync_prefix = '')
+      init_sync_processes(sync_name, sync_prefix)
       @sync_processes.each { |sync_process|
         sync_process.sync
       }
     end
 
-    def start_container(sync_name = nil)
-      init_sync_processes(sync_name)
+    def start_container(sync_name = nil, sync_prefix = '')
+      init_sync_processes(sync_name, sync_prefix)
       @sync_processes.each { |sync_process|
         sync_process.start_container
       }
     end
 
-    def run(sync_name = nil)
-      init_sync_processes(sync_name)
+    def run(sync_name = nil, sync_prefix = '')
+      init_sync_processes(sync_name, sync_prefix)
 
       @sync_processes.each { |sync_process|
         sync_process.run
@@ -136,8 +137,8 @@ module DockerSync
       return sync_process
     end
 
-    def stop
-      init_sync_processes
+    def stop(sync_name = nil, sync_prefix = '')
+      init_sync_processes(sync_name, sync_prefix)
       @sync_processes.each { |sync_process|
         sync_process.stop
         unless sync_process.watch_thread.nil?

--- a/tasks/stack/stack.thor
+++ b/tasks/stack/stack.thor
@@ -9,6 +9,7 @@ require 'docker-sync/config/project_config'
 class Stack < Thor
   class_option :config, :aliases => '-c', :default => nil, :type => :string, :desc => 'Path of the docker_sync config'
   class_option :sync_name, :aliases => '-n', :type => :string, :desc => 'If given, only this sync configuration will be references/started/synced'
+  class_option :sync_prefix, :aliases => '-p',:type => :string, :default => '', :desc => 'If given, sync names will be prefixed with this string'
   class_option :version, :aliases => '-v',:type => :boolean, :default => false, :desc => 'prints out the version of docker-sync and exits'
 
   desc '--version, -v', 'Prints out the version of docker-sync and exits'
@@ -43,7 +44,7 @@ class Stack < Thor
     say_status 'note:', 'You can also run docker-sync in the background with docker-sync --daemon'
 
     @sync_manager = DockerSync::SyncManager.new(config: config)
-    @sync_manager.run(options[:sync_name])
+    @sync_manager.run(options[:sync_name], options[:sync_prefix])
     global_options = @sync_manager.global_options
     @compose_manager = ComposeManager.new(global_options)
 
@@ -89,7 +90,7 @@ class Stack < Thor
     say_status 'success', 'Finished cleaning up your app stack', :green
 
     # now shutdown sync
-    @sync_manager.clean(options[:sync_name])
+    @sync_manager.clean(options[:sync_name], options[:sync_prefix])
     say_status 'success', 'Finished cleanup. Removed stopped, removed sync container and removed their volumes', :green
   end
 end


### PR DESCRIPTION
A solution to #439 which when a --sync-prefix is added, volumes specified in the docker-sync.yml will be prefixed with the specified value, feedback appreciated.

`docker-sync start --sync_prefix=myprefix_`