### PR TITLE
fix default host ip detection in non osx environment

### DIFF
--- a/lib/docker-sync/sync_process.rb
+++ b/lib/docker-sync/sync_process.rb
@@ -71,16 +71,14 @@ module DockerSync
     end
 
     def get_host_ip_default
-      return '127.0.0.1' if Dependencies::Docker::Driver.docker_for_mac?
+      return '127.0.0.1' unless Dependencies::Docker::Driver.docker_toolbox?
 
-      if Dependencies::Docker::Driver.docker_toolbox?
-        cmd = 'docker-machine ip $(docker-machine active)'
-        stdout, stderr, exit_status = Open3.capture3(cmd)
-        unless exit_status.success?
-          raise "Error getting sync_host_ip automatically, exit code #{$?.exitstatus} ... #{stderr}"
-        end
-        return stdout.gsub("\n",'')
+      cmd = 'docker-machine ip $(docker-machine active)'
+      stdout, stderr, exit_status = Open3.capture3(cmd)
+      unless exit_status.success?
+        raise "Error getting sync_host_ip automatically, exit code #{$?.exitstatus} ... #{stderr}"
       end
+      stdout.gsub("\n",'')
     end
 
     def run


### PR DESCRIPTION
fix #444 and also address issue in windows installation mentioned in [wiki](https://github.com/EugenMayer/docker-sync/wiki/docker-sync-on-Windows#12-sample-docker-sycyml)

excerpt from wiki:

```
	version: "2"
	options:
	  verbose: true
	syncs:
	  app-unison-sync: # tip: add -sync and you keep consistent names als a convention
	    sync_args: ['-perms=0'] #required for two way sync ie generators, etc
	    sync_strategy: 'unison' 
	    sync_host_ip: '127.0.0.1' #host ip isn't properly inferred
	    sync_excludes: ['.gitignore', '.idea/*','.git/*', '*.coffee', '*.scss', '*.sass','*.log']
	    src: './'
```