### PR TITLE
FreeBSD support using rsync mechanism

### DIFF
--- a/example/docker-sync.yml
+++ b/example/docker-sync.yml
@@ -90,6 +90,8 @@ syncs:
     sync_host_ip: 'auto'
     # should be a unique port this sync instance uses on the host to offer the rsync service on
     sync_host_port: 20871
+    # set of IPs (10.0.2.2) or networks (10.0.0.0/8) that will be granted access to this rsync service, useful when running on FreeBSD with Virtualbox and a host-only interface
+    # sync_host_allow: '10.0.0.0/8'
     # optionl, a list of excludes for rsync - see rsync docs for details
     sync_excludes: ['Gemfile.lock', 'Gemfile', 'config.rb', '.sass-cache/', 'sass/', 'sass-cache/', 'composer.json' , 'bower.json', 'package.json', 'Gruntfile*', 'bower_components/', 'node_modules/', '.gitignore', '.git/', '*.coffee', '*.scss', '*.sass']
     # optional: use this to switch to rsync verbose mode

--- a/lib/docker-sync/dependencies.rb
+++ b/lib/docker-sync/dependencies.rb
@@ -14,6 +14,7 @@ module DockerSync
       return if ENV['DOCKER_SYNC_SKIP_DEPENDENCIES_CHECK']
       return ensure_all_for_mac!(config)   if Environment.mac?
       return ensure_all_for_linux!(config) if Environment.linux?
+      return ensure_all_for_freebsd!(config) if Environment.freebsd?
       raise(UNSUPPORTED_OPERATING_SYSTEM)
     end
 
@@ -27,6 +28,12 @@ module DockerSync
 
     def self.ensure_all_for_linux!(_config)
       Docker.ensure!
+    end
+
+    def self.ensure_all_for_freebsd!(config)
+      Docker.ensure!
+      Unison.ensure!  if config.unison_required?
+      Rsync.ensure!   if config.rsync_required?
     end
   end
 end

--- a/lib/docker-sync/dependencies/docker_driver.rb
+++ b/lib/docker-sync/dependencies/docker_driver.rb
@@ -11,7 +11,7 @@ module DockerSync
         end
 
         def self.docker_toolbox?
-          return false unless Environment.mac?
+          return false unless Environment.mac? || Environment.freebsd?
           return false unless find_executable0('docker-machine')
           return @docker_toolbox if defined? @docker_toolbox
           @docker_toolbox = system('docker info | grep -q "Operating System: Boot2Docker"')

--- a/lib/docker-sync/dependencies/package_managers/pkg.rb
+++ b/lib/docker-sync/dependencies/package_managers/pkg.rb
@@ -1,0 +1,24 @@
+module DockerSync
+  module Dependencies
+    module PackageManager
+      class Pkg < Base
+        PKG_NOT_AVAILABLE = 'PKG is not installed. Please install it and try again.'.freeze
+
+        def self.available?
+          return @available if defined? @available
+          @available = find_executable0('pkg')
+        end
+
+        def self.ensure!
+          raise(PKG_NOT_AVAILABLE) unless available?
+        end
+
+        private
+
+        def install_cmd
+          "pkg install -y #{package}"
+        end
+      end
+    end
+  end
+end

--- a/lib/docker-sync/environment.rb
+++ b/lib/docker-sync/environment.rb
@@ -11,5 +11,9 @@ module DockerSync
       return @mac if defined? @mac
       @mac = OS.mac?
     end
+
+    def self.freebsd?
+      @freebsd ||= OS.freebsd?
+    end
   end
 end

--- a/lib/docker-sync/sync_strategy/rsync.rb
+++ b/lib/docker-sync/sync_strategy/rsync.rb
@@ -96,8 +96,9 @@ module DockerSync
 
             user_mapping = get_user_mapping
             group_mapping = get_group_mapping
+            docker_env = get_docker_env
 
-            cmd = "docker run -p '#{@options['sync_host_port']}:873' -v #{volume_name}:#{@options['dest']} #{user_mapping} #{group_mapping} -e VOLUME=#{@options['dest']} -e TZ=${TZ-`readlink /etc/localtime | sed -e 's,/usr/share/zoneinfo/,,'`} --name #{container_name} -d #{@docker_image}"
+            cmd = "docker run -p '#{@options['sync_host_port']}:873' -v #{volume_name}:#{@options['dest']} #{user_mapping} #{group_mapping} #{docker_env} --name #{container_name} -d #{@docker_image}"
           else # container already created, just start / reuse it
             say_status 'ok', "starting #{container_name} container", :white if @options['verbose']
             cmd = "docker start #{container_name}"
@@ -129,6 +130,14 @@ module DockerSync
           #group_mapping = "#{group_mapping} -e GROUP_ID=#{@options['sync_groupid']}"
         end
         return group_mapping
+      end
+
+      def get_docker_env
+        env_mapping = []
+        env_mapping << "-e VOLUME=#{@options['dest']}"
+        env_mapping << "-e TZ=${TZ-`readlink /etc/localtime | sed -e 's,/usr/share/zoneinfo/,,'`}"
+        env_mapping << "-e ALLOW=#{@options['sync_host_allow']}" if @options['sync_host_allow']
+        env_mapping.join(' ')
       end
 
       def stop_container

--- a/spec/lib/docker-sync/dependencies/package_manager_spec.rb
+++ b/spec/lib/docker-sync/dependencies/package_manager_spec.rb
@@ -33,6 +33,7 @@ RSpec.describe DockerSync::Dependencies::PackageManager do
       expect(subject).to match_array [
         DockerSync::Dependencies::PackageManager::Brew,
         DockerSync::Dependencies::PackageManager::Apt,
+        DockerSync::Dependencies::PackageManager::Pkg,
         DockerSync::Dependencies::PackageManager::Yum
       ]
     end


### PR DESCRIPTION
This PR brings support for `FreeBSD` platform using `rsync` mechanism (`unison` should also be possible but I haven't tried it yet). 

Docker support on FreeBSD is possible through `docker-machine` using `virtualbox` running a `boot2docker` virtualmachine which is then connected to the host by the `generic` driver.

Overall changes:
* Support for `FreeBSD` environment
* Configurable `rsyncd` allowed hosts by `sync_host_allow` `docker-sync.yml` value