### PR TITLE
Fix D4M edge strategy detection

### DIFF
--- a/lib/docker-sync/dependencies/docker_driver.rb
+++ b/lib/docker-sync/dependencies/docker_driver.rb
@@ -5,10 +5,7 @@ module DockerSync
         def self.docker_for_mac?
           return false unless Environment.mac?
           return @docker_for_mac if defined? @docker_for_mac
-          @docker_for_mac =
-            system('docker info | grep -q "Operating System: Alpine Linux"') ||
-            system('docker info | grep -q "Operating System: Docker for Mac"') &&
-            system('docker info | grep -q "Docker Root Dir: /var/lib/docker"')
+          @docker_for_mac = system('ps x | grep MacOS | grep -q com.docker.osx.hyperkit.linux')
         end
 
         def self.docker_toolbox?

--- a/lib/docker-sync/dependencies/docker_driver.rb
+++ b/lib/docker-sync/dependencies/docker_driver.rb
@@ -6,7 +6,8 @@ module DockerSync
           return false unless Environment.mac?
           return @docker_for_mac if defined? @docker_for_mac
           @docker_for_mac =
-            system('docker info | grep -q "Operating System: Alpine Linux"') &&
+            system('docker info | grep -q "Operating System: Alpine Linux"') ||
+            system('docker info | grep -q "Operating System: Docker for Mac"') &&
             system('docker info | grep -q "Docker Root Dir: /var/lib/docker"')
         end
 

--- a/spec/lib/docker-sync/dependencies/docker_driver_spec.rb
+++ b/spec/lib/docker-sync/dependencies/docker_driver_spec.rb
@@ -18,9 +18,9 @@ RSpec.describe DockerSync::Dependencies::Docker::Driver do
       it { is_expected.to execute_nothing }
     end
 
-    it 'checks if Docker is running in Alpine Linux (Hyperkit)' do
+    it 'checks if Docker is running in Hyperkit' do
       subject
-      expect(described_class).to have_received(:system).with('docker info | grep -q "Operating System: Alpine Linux"')
+      expect(described_class).to have_received(:system).with('ps x | grep MacOS | grep -q com.docker.osx.hyperkit.linux')
     end
 
     it 'checks if Docker is running from /var/lib/docker' do


### PR DESCRIPTION
With the newest version of Docker for Mac edge (17.10.0-ce-mac36), `docker info | grep 'Operating System'` outputs: `Operating System: Docker for Mac`.

This results in docker-sync choosing the 'unison' strategy which seems broken.