### PR TITLE
Fix sync config checks (unison, rsync, fswatch)

### DIFF
--- a/lib/docker-sync/config/project_config.rb
+++ b/lib/docker-sync/config/project_config.rb
@@ -48,20 +48,21 @@ module DockerSync
 
     def unison_required?
       # noinspection RubyUnusedLocalVariable
-      config['syncs'].any? { |sync_config|
+      config['syncs'].any? { |name, sync_config|
         sync_config['sync_strategy'] == 'unison' || sync_config['watch_strategy'] == 'unison'
       }
     end
 
     def rsync_required?
       # noinspection RubyUnusedLocalVariable
-      config['syncs'].any? { |sync_config|
+      config['syncs'].any? { |name, sync_config|
         sync_config['sync_strategy'] == 'rsync'
       }
     end
 
     def fswatch_required?
-      config['syncs'].any? { |sync_config|
+      # noinspection RubyUnusedLocalVariable
+      config['syncs'].any? { |name, sync_config|
         sync_config['watch_strategy'] == 'fswatch'
       }
     end


### PR DESCRIPTION
Fixes #482 

```ruby
puts config['syncs']
```
outputs something like this:

```js
{
  "first-sync" => {
    "sync_strategy" => "native_osx",
    "watch_strategy" => "remotelogs",
    "src" => "/Users/tripox/sync-test/2"
  },
  "second-sync" => {
    "sync_strategy" => "native_osx",
    "watch_strategy" => "remotelogs",
    "src" => "/Users/tripox/sync-test/1"
  },
}
```

We are looping through this, so `name` or the key is required.