### PR TITLE
Use pgrep for Docker for Mac detection

### DIFF
--- a/lib/docker-sync/dependencies/docker_driver.rb
+++ b/lib/docker-sync/dependencies/docker_driver.rb
@@ -5,7 +5,7 @@ module DockerSync
         def self.docker_for_mac?
           return false unless Environment.mac?
           return @docker_for_mac if defined? @docker_for_mac
-          @docker_for_mac = system('ps x | grep MacOS | grep -q com.docker.osx.hyperkit.linux')
+          @docker_for_mac = system('pgrep -q com.docker.osx.hyperkit.linux')
         end
 
         def self.docker_toolbox?

--- a/spec/lib/docker-sync/dependencies/docker_driver_spec.rb
+++ b/spec/lib/docker-sync/dependencies/docker_driver_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe DockerSync::Dependencies::Docker::Driver do
 
     it 'checks if Docker is running in Hyperkit' do
       subject
-      expect(described_class).to have_received(:system).with('ps x | grep MacOS | grep -q com.docker.osx.hyperkit.linux')
+      expect(described_class).to have_received(:system).with('pgrep -q com.docker.osx.hyperkit.linux')
     end
 
     it 'is memoized' do


### PR DESCRIPTION
A way more simple, cleaner and reliable way to detect if the process `com.docker.osx.hyperkit.linux` is running.