### PR TITLE
Fix Docker configuration detection in RSpec

### DIFF
--- a/spec/helpers/docker_for_mac_config_check.rb
+++ b/spec/helpers/docker_for_mac_config_check.rb
@@ -9,7 +9,7 @@ module DockerForMacConfigCheck
     return unless File.exist?(D4M_MOUNTS_FILE)
     File.readlines(D4M_MOUNTS_FILE).each do |mount_line|
       mount_src, _mount_dst = mount_line.split(':')
-      Pathname.new(Dir.tmpdir).ascend do |parent_dir|
+      Pathname.new(File.realpath(Dir.tmpdir)).ascend do |parent_dir|
         return if File.realpath(parent_dir) == File.realpath(mount_src)
       end
     end


### PR DESCRIPTION
That's a small fix to correctly detect if Docker For Mac has the temporary directory shared with HyperKit when running the specs.

It was previously failing in case you had `/var` being a symlink to `/private/var` (which was the case on my system, no idea why 🤷‍♂️). Adding `File.realpath` here fixes it by checking the *actual* path.

Not a big deal, no rush: it only determines whether to print a warning message or not before the test suite (_i.e._ merging this or not won't change the test suite result).