### PR TITLE
Use Monit to auto restart if CPU usage high in Native OSX strategy

### DIFF
--- a/example/docker-sync.yml
+++ b/example/docker-sync.yml
@@ -117,9 +117,9 @@ syncs:
     # optional: default is fswatch, if set to disable, no watcher will be used and you would need to start the sync manually
     watch_strategy: 'fswatch'
 
-    # monit is used to monitor the health of unison in the native_osx strategy and can restart unison if it detects a problem
-    # optional: use this to switch monit monitoring off
-    monit_enabled: true
+    # monit can be used to monitor the health of unison in the native_osx strategy and can restart unison if it detects a problem
+    # optional: use this to switch monit monitoring on
+    monit_enabled: false
     # optional: use this to change how many seconds between each monit check (cycle)
     monit_interval: 5
     # optional: use this to change how many consecutive times high cpu usage must be observed before unison is restarted

--- a/example/docker-sync.yml
+++ b/example/docker-sync.yml
@@ -116,3 +116,11 @@ syncs:
     watch_args: '-v'
     # optional: default is fswatch, if set to disable, no watcher will be used and you would need to start the sync manually
     watch_strategy: 'fswatch'
+
+    # monit is used to monitor the health of unison in the native_osx strategy and can restart unison if it detects a problem
+    # optional: use this to switch monit monitoring off
+    monit_enabled: true
+    # optional: use this to change how many seconds between each monit check (cycle)
+    monit_interval: 5
+    # optional: use this to change how many consecutive times high cpu usage must be observed before unison is restarted
+    monit_high_cpu_cycles: 2

--- a/lib/docker-sync/sync_strategy/native_osx.rb
+++ b/lib/docker-sync/sync_strategy/native_osx.rb
@@ -65,6 +65,8 @@ module DockerSync
           env['OWNER_UID'] = @options['sync_userid'] if @options.key?('sync_userid')
         end
 
+        env['ENABLE_MONIT'] = @options.fetch 'enable_monit', true
+
         host_disk_mount_mode = '' # see https://github.com/moby/moby/pull/31047
         host_disk_mount_mode = ":#{@options['host_disk_mount_mode']}" if @options.key?('host_disk_mount_mode')
 

--- a/lib/docker-sync/sync_strategy/native_osx.rb
+++ b/lib/docker-sync/sync_strategy/native_osx.rb
@@ -65,7 +65,15 @@ module DockerSync
           env['OWNER_UID'] = @options['sync_userid'] if @options.key?('sync_userid')
         end
 
-        env['ENABLE_MONIT'] = @options.fetch 'enable_monit', true
+        monit_options = {
+          monit_enable: 'MONIT_ENABLE',
+          monit_interval: 'MONIT_INTERVAL',
+          monit_high_cpu_cycles: 'MONIT_HIGH_CPU_CYCLES',
+        }
+
+        monit_options.each do |key, env_key|
+          env[env_key] = @options[key.to_s] if @options.key?(key.to_s)
+        end
 
         host_disk_mount_mode = '' # see https://github.com/moby/moby/pull/31047
         host_disk_mount_mode = ":#{@options['host_disk_mount_mode']}" if @options.key?('host_disk_mount_mode')


### PR DESCRIPTION
- Fixes #497
- Issue has repro steps
- Adding monit to Native OSX image done here: https://github.com/EugenMayer/docker-image-unison/pull/11
- This PR adds ability to control three configuration options from the config file

---

- `monit_enable` - Control if `monit` is used, default `false`
- `monit_interval` - How often in seconds `monit` performs check, default `5`
- `monit_high_cpu_cycles` - How many cycles of `monit` checks need to have high cpu usage (>50%) to trigger a restart, default `2`