### PR TITLE
Fix monit_enabled typo / docs mismatch

### DIFF
--- a/lib/docker-sync/sync_strategy/native_osx.rb
+++ b/lib/docker-sync/sync_strategy/native_osx.rb
@@ -66,7 +66,7 @@ module DockerSync
         end
 
         monit_options = {
-          monit_enable: 'MONIT_ENABLE',
+          monit_enabled: 'MONIT_ENABLE',
           monit_interval: 'MONIT_INTERVAL',
           monit_high_cpu_cycles: 'MONIT_HIGH_CPU_CYCLES',
         }


### PR DESCRIPTION
PR #521 had a typo that causes the `monit_enabled` option to have no effect.

As a forward-compatible temporary workaround, one can set both options:

```yaml
monit_enable: true
monit_enabled: true
```

/cc @ricmatsui