### PR TITLE
replaced &> /dev/null with 2>&1 > /dev/null

### DIFF
--- a/lib/docker-sync/dependencies/docker.rb
+++ b/lib/docker-sync/dependencies/docker.rb
@@ -11,7 +11,7 @@ module DockerSync
 
       def self.running?
         return @running if defined? @running
-        @running = system('docker ps &> /dev/null')
+        @running = system('docker ps 2>&1 > /dev/null')
       end
 
       def self.ensure!

--- a/lib/docker-sync/dependencies/unox.rb
+++ b/lib/docker-sync/dependencies/unox.rb
@@ -13,7 +13,7 @@ module DockerSync
 
       def self.available?
         return @available if defined? @available
-        cmd = 'brew list unox &> /dev/null'
+        cmd = 'brew list unox 2>&1 > /dev/null'
         @available = defined?(Bundler) ? Bundler.clean_system(cmd) : system(cmd)
       end
 

--- a/spec/integration/native-osx_strategy_spec.rb
+++ b/spec/integration/native-osx_strategy_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe 'native_osx strategy', command_execution: :allowed, if: OS.mac? d
 
   before :all do
     # Cleanup potentially leftover container from previously killed test suite
-    system('docker rm -f -v docker_sync_specs-sync &> /dev/null')
+    system('docker rm -f -v docker_sync_specs-sync 2>&1 > /dev/null')
   end
 
   describe 'start' do


### PR DESCRIPTION
When running with WSL default shell is `sh` and not `bash`, so output is not captured and printed to STDOUT. The operator `&>` does only work with `bash`