### PR TITLE
Fix exception thrown on docker-sync stop with unison setup

### DIFF
--- a/lib/docker-sync/watch_strategy/unison.rb
+++ b/lib/docker-sync/watch_strategy/unison.rb
@@ -27,8 +27,11 @@ module DockerSync
       end
 
       def stop
-        Process.kill 'TERM', @watch_fork
-        Process.wait @watch_fork
+        # Make sure @watch_fork is not nil otherwise a TypeError is thrown
+        if @watch_fork
+          Process.kill 'TERM', @watch_fork
+          Process.wait @watch_fork
+        end
       end
 
       def clean


### PR DESCRIPTION
This will address the `no implicit conversion from nil to integer (TypeError)` exception that is thrown when using docker-sync stop as mentioned in #356.

I do not have a ton of experience with Ruby but it appeared the object was nil and not what was expected by the Process module. The unison process still start and stops normally after the fix.

Hope to see this make it in to the next release!