### PR TITLE
WIP: Provide the means to support 1-way synchronization of files from cont…

### DIFF
--- a/lib/docker-sync/config/project_config.rb
+++ b/lib/docker-sync/config/project_config.rb
@@ -57,7 +57,7 @@ module DockerSync
     def rsync_required?
       # noinspection RubyUnusedLocalVariable
       config['syncs'].any? { |name, sync_config|
-        sync_config['sync_strategy'] == 'rsync'
+        sync_config['sync_strategy'] == 'rsync' || sync_config['sync_strategy'] == 'reverse_rsync'
       }
     end
 
@@ -151,6 +151,7 @@ module DockerSync
       def default_watch_strategy(sync_config)
         case sync_strategy_for(sync_config)
         when 'rsync' then 'fswatch'
+        when 'reverse_rsync' then 'dummy'
         when 'unison' then 'unison'
         when 'native' then 'dummy'
         when 'native_osx' then 'remotelogs'

--- a/lib/docker-sync/sync_process.rb
+++ b/lib/docker-sync/sync_process.rb
@@ -1,6 +1,7 @@
 require 'thor/shell'
 # noinspection RubyResolve
 require 'docker-sync/sync_strategy/rsync'
+require 'docker-sync/sync_strategy/reverse_rsync'
 require 'docker-sync/sync_strategy/unison'
 require 'docker-sync/sync_strategy/native'
 require 'docker-sync/sync_strategy/native_osx'
@@ -44,6 +45,8 @@ module DockerSync
       case @options['sync_strategy']
       when 'rsync'
         @sync_strategy = DockerSync::SyncStrategy::Rsync.new(@sync_name, @options)
+      when 'reverse_rsync'
+        @sync_strategy = DockerSync::SyncStrategy::ReverseRsync.new(@sync_name, @options)
       when 'unison'
         @sync_strategy = DockerSync::SyncStrategy::Unison.new(@sync_name, @options)
       when 'native'

--- a/lib/docker-sync/sync_strategy/reverse_rsync.rb
+++ b/lib/docker-sync/sync_strategy/reverse_rsync.rb
@@ -1,0 +1,192 @@
+require 'thor/shell'
+require 'terminal-notifier'
+require 'tmpdir'
+require 'timeout'
+
+module DockerSync
+  module SyncStrategy
+    class ReverseRsync
+      include Thor::Shell
+
+      @options
+      @sync_name
+      @watch_thread
+      @rsyncd_conf_file
+      @rsyncd_pid_file
+
+      def initialize(sync_name, options)
+        @sync_name = sync_name
+        @options = options
+        # if a custom image is set, apply it
+        if @options.key?('image')
+          @docker_image = @options['image']
+        else
+          @docker_image = 'zluiten/fswatch-rsync'
+        end
+
+        begin
+          Dependencies::Rsync.ensure!
+        rescue StandardError => e
+          say_status 'error', "#{@sync_name} has been configured to reverse sync with rsync, but no rsync binary available", :red
+          say_status 'error', e.message, :red
+          exit 1
+        end
+
+        container_name = get_container_name
+
+        temp = Dir.tmpdir
+        @rsyncd_conf_file = "#{temp}/rsyncd-#{container_name}.conf"
+        @rsyncd_pid_file = "#{temp}/rsyncd-#{container_name}.pid"
+      end
+
+      def start_rsyncd
+        File.open(@rsyncd_conf_file, "w") do |file|
+          file.write(<<NOW
+pid file = #{@rsyncd_pid_file}
+port = #{@options['sync_host_port']}
+reverse lookup = no
+munge symlinks = no
+use chroot = no
+
+[#{@sync_name}]
+hosts deny = *
+hosts allow = 127.0.0.1
+read only = no
+path = #{@options['src']}
+NOW
+          )
+        end
+
+        if File.exist?(@rsyncd_pid_file)
+          stop_rsyncd
+        end
+
+        cmd = "rsync --daemon --config=\"#{@rsyncd_conf_file}\""
+        say_status 'ok', "Starting rsync daemon with #{cmd}", :green
+
+        pid = Process.spawn(cmd)
+        Process.detach(pid)
+      end
+
+      def stop_rsyncd
+        if File.exist?(@rsyncd_pid_file)
+          begin
+            pid = File.read("#{@rsyncd_pid_file}")
+            Process.kill(:INT, -(Process.getpgid(pid.to_i)))
+            Timeout::timeout(30) do
+              loop do
+
+                pid_status = system("ps -p #{pid.to_i} > /dev/null")
+
+                if pid_status
+                  sleep 1
+                else
+                  say_status 'ok', "Stopping rsync daemon for #{get_container_name}"
+                  return
+                end
+              end
+            end
+          rescue Timeout::Error
+            say_status 'error', "Failed to stop rsync daemon for #{get_container_name} within 30 seconds", :red
+          end
+        end
+
+      end
+
+      def run
+        start_container
+        sync
+      end
+
+      def sync
+        # nop
+      end
+
+      def get_container_name
+        return "#{@sync_name}"
+      end
+
+      def get_volume_name
+        return @sync_name
+      end
+
+      # starts a reverse-rsync docker container and starts an rsync daemon on the host listening on the configured port
+      # the container exposes a named volume and it syncs volume changes to the host using rsync command
+      def start_container
+        say_status 'ok', "Starting reverse-rsync for sync #{@sync_name}", :white
+
+        container_name = get_container_name
+        volume_name = get_volume_name
+
+        start_rsyncd
+
+        running = `docker ps --filter 'status=running' --filter 'name=#{container_name}' --format "{{.Names}}" | grep '^#{container_name}$'`
+        if running == '' # container is yet not running
+          say_status 'ok', "#{container_name} container not running", :white if @options['verbose']
+          exists = `docker ps --filter "status=exited" --filter "name=#{container_name}" --format "{{.Names}}" | grep '^#{container_name}$'`
+          if exists == '' # container has yet not been created
+            say_status 'ok', "creating #{container_name} container", :white if @options['verbose']
+
+            docker_env = get_docker_env
+
+            cmd = "docker run -v #{volume_name}:#{@options['dest']} #{docker_env} --name #{container_name} -d #{@docker_image}"
+          else # container already created, just start / reuse it
+            say_status 'ok', "starting #{container_name} container", :white if @options['verbose']
+            cmd = "docker start #{container_name}"
+          end
+          say_status 'command', cmd, :white if @options['verbose']
+          `#{cmd}` || raise('Start failed')
+        else
+          say_status 'ok', "#{container_name} container still running", :blue if @options['verbose']
+        end
+        say_status 'ok', "#{container_name}: starting initial sync of #{@options['src']}", :white if @options['verbose']
+        # this sleep is needed since the container could be not started
+        sleep 3
+        sync
+        say_status 'success', 'Reverse rsync container started', :green
+      end
+
+      def get_docker_env
+        sync_excludes = []
+        unless @options['sync_excludes'].nil?
+          sync_excludes = @options['sync_excludes'].map {|pattern| "--exclude \"#{pattern}\""
+          }
+        end
+
+        env_mapping = []
+        env_mapping << "-e VOLUME=#{@options['dest']}"
+        env_mapping << "-e TZ=$(basename $(dirname `readlink /etc/localtime`))/$(basename `readlink /etc/localtime`)"
+        env_mapping << "-e ALLOW=#{@options['sync_host_allow']}" if @options['sync_host_allow']
+        env_mapping << "-e RSYNC_MODULE=#{get_volume_name}"
+        env_mapping << "-e RSYNC_HOST_PORT=#{@options['sync_host_port']}"
+        env_mapping << "-e SYNC_EXCLUDE_ARGS='#{sync_excludes.join(' ')}'"
+        env_mapping.join(' ')
+      end
+
+      def stop_container
+        `docker ps | grep #{get_container_name} && docker stop #{get_container_name}`
+        stop_rsyncd
+      end
+
+      def reset_container
+        stop_container
+        `docker ps -a | grep #{get_container_name} && docker rm #{get_container_name}`
+        `docker volume ls -q | grep #{get_volume_name} && docker volume rm #{get_volume_name}`
+      end
+
+      def clean
+        reset_container
+      end
+
+      def stop
+        say_status 'ok', "Stopping sync container #{get_container_name}"
+        begin
+          stop_container
+        rescue StandardError => e
+          say_status 'error', "Stopping failed of #{get_container_name}:", :red
+          puts e.message
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
**TL;DR:**
Provides the means to support 1-way synchronization of files from container to host
 
See https://github.com/EugenMayer/docker-sync/issues/588
 - Starts an rsync daemon on the host listening on the specified port
 - Starts a container that synchorizes the volume upon fs change events using the rsync command targeting the started rsync daemon on the host

This gem includes the current changes: [docker-sync-dev.gem.zip](https://github.com/EugenMayer/docker-sync/files/2336699/docker-sync-dev.gem.zip)

**Status**
Successfully using this strategy for a week now with 
 - a sync-point with 13560 files (96M)
 - a sync-point with 16797 files (411M)
 - a sync-point with 37465 files (319M)

Startup is not slower and files are synced within seconds.

**1-way sync**
The idea is to provide a way to synchronize certain directories from **container to host**. Exactly the opposite of what the rsync-strategy does (from host to container). This can be useful for directories that are generated/changed **only** in the container.

When the `reverse_rsync`-strategy is configured, basically this is done:

- an rsync daemon is started on the host listening on the specified port by `sync_host_port`, it's configured with the docker-sync.yml `src` value as a [module](https://download.samba.org/pub/rsync/rsyncd.conf.html).
- a [zluiten/fswatch-rsync](https://hub.docker.com/r/zluiten/fswatch-rsync/) container is started with the configured volume mounted. This container watches file changes by `fswatch` and starts an rsync command upon an fs event.

**!!WARNING!!** This **will** delete files on the host that are not inside the container as this is a 1-way sync from container to host and assumes that the container is always leading.

Please note that an rsync daemon is started for each configured `reverse_rsync` container, therefore each `sync_host_port` must be unique. (This could possibly be optimized by reusing an already started rsync daemon and just add a new module, but it has some side effects.)

**docker-sync.yml**
```yaml
version: "2"

options:
  compose-file-path: 'docker-compose.yml'
  verbose: true
  max-attempt: 500
syncs:
  #IMPORTANT: ensure this name is unique and does not match your other application container name
  project-sync: # tip: add -sync and you keep consistent names as a convention
    src: ./repositories/project
    sync_strategy: 'native_osx'
    sync_userid: '33'
    sync_excludes:
      - 'vendor'
  vendor-sync: # tip: add -sync and you keep consistent names as a convention
    src: ./repositories/project/vendor
    sync_strategy: 'reverse_rsync'
    sync_userid: '33'
    sync_host_port: 20873
    sync_excludes:
      - '/some-uninteresting-vendor'
```

**TODO**
- [ ] Add unit tests
- [ ] Validate configuration upon `sync:start` (f.e. detect in use `sync_host_port` values)
- [ ] Review rsyncd pid file location?
- [ ] Add some useful code comments
- [ ] Update documentation
- [ ] Add some performance test results
