### PR TITLE
Na wait for rsync daemon

### DIFF
--- a/lib/docker-sync/sync_strategy/rsync.rb
+++ b/lib/docker-sync/sync_strategy/rsync.rb
@@ -41,7 +41,6 @@ module DockerSync
         say_status 'command', cmd, :white if @options['verbose']
 
         out = `#{cmd}`
-        
         if $?.exitstatus > 0
           say_status 'error', "Error starting sync, exit code #{$?.exitstatus}", :red
           say_status 'message', out

--- a/lib/docker-sync/sync_strategy/rsync.rb
+++ b/lib/docker-sync/sync_strategy/rsync.rb
@@ -71,6 +71,21 @@ module DockerSync
         return args
       end
 
+      # sleep until rsync --dry-run succeeds in connecting to the daemon on the configured IP and port. 
+      def health_check
+        health_check_cmd = "rsync --dry-run rsync://#{@options['sync_host_ip']}:#{@options['sync_host_port']}:: 2> /dev/null"
+
+        retry_counter = 0
+        
+        health_check_status = `#{health_check_cmd}`
+        while health_check_status == '' && retry_counter < 10 do
+          say_status 'ok', "waiting for rsync daemon on rsync://#{@options['sync_host_ip']}:#{@options['sync_host_port']}", :white if @options['verbose']
+          retry_counter += 1
+          health_check_status = `#{health_check_cmd}`
+          sleep 1
+        end
+      end
+
       def get_container_name
         return "#{@sync_name}"
       end
@@ -108,18 +123,9 @@ module DockerSync
         else
           say_status 'ok', "#{container_name} container still running", :blue if @options['verbose']
         end
-        health_check_cmd = "rsync --dry-run rsync://#{@options['sync_host_ip']}:#{@options['sync_host_port']}:: 2> /dev/null"
-        retry_counter = 0
-        health_check = `#{health_check_cmd}`
-        while health_check == '' && retry_counter < 10 do #rsync daemon isn't listening yet
-          say_status 'ok', "waiting for rsync daemon to start in container #{container_name}", :white if @options['verbose']
-          retry_counter += 1
-          health_check = `#{health_check_cmd}`
-          sleep 1
-        end
         say_status 'ok', "#{container_name}: starting initial sync of #{@options['src']}", :white if @options['verbose']
-        # this sleep is needed since the container could be not started
-        sleep 3
+
+        health_check
         sync
         say_status 'success', 'Rsync server started', :green
       end


### PR DESCRIPTION
During start up, our team has been getting:
```
rsync error: error in rsync protocol data stream (code 12) at /BuildRoot/Library/Caches/com.apple.xbs/Sources/rsync/rsync-52/rsync/io.c(453) [receiver=2.6.9]
```

In our testing we found that it took approx 2-4s for the sync container to not only be running, but for the rsync daemon to be listening on the desired port. The `start_container` method in rsync.rb seemed to handle most of these start delays with a `sleep 3` but if the rsync daemon is still not available after 3s, the initial sync is attempted anyway, resulting in the above error.

The connection to the rsync daemon can be tested with the `--dry-run` flag. So I've attempted a `health_check` method that will use this call to wait until rsync is listening on the desired port and container IP.

This `health_check` method will wait until the` rsync --dry-run...` command returns a non empty string. It will only try 10times to prevent an infinite loop, and any issues syncing after that are handled normally by the `sync` method.

Thanks! 