### PR TITLE
Fixed regression of #9ffd23

### DIFF
--- a/lib/docker-sync/update_check.rb
+++ b/lib/docker-sync/update_check.rb
@@ -89,7 +89,7 @@ class UpdateChecker
     # update the timestamp
     @config.update! 'update_last_check' => DateTime.now.iso8601(9)
 
-    check = docker_sync_update_check7
+    check = docker_sync_update_check
     if check.update_available
       say_status 'warning',"There is an update (#{check.latest_version}) available (current version #{check.current_version}). Please update before you continue",:yellow
       if yes?("Shall I update docker-sync to #{check.latest_version} for you?")


### PR DESCRIPTION
I got an error after updating to v0.5.8, as docker-sync was calling an unknown method

```
'check_and_warn': undefined local variable or method 'docker_sync_update_check7' for #<UpdateChecker:0x00007fba6c35f970> (NameError)
Did you mean?  docker_sync_update_check
```

This PR fixes this regression, introduced in 9ffd23b5a30c63cfe3f057d14a4e433ced6d420c