### PR TITLE
Fix exit-code

### DIFF
--- a/tasks/sync/sync.thor
+++ b/tasks/sync/sync.thor
@@ -156,7 +156,7 @@ class Sync < Thor
       # Check to see if we're already running:
       if daemon_running?
         say_status 'warning', 'docker-sync already started for this configuration', :yellow
-        exit 1
+        exit 0
       end
 
       # If we're daemonizing, run a sync first to ensure the containers exist so that a docker-compose up won't fail:

--- a/tasks/sync/sync.thor
+++ b/tasks/sync/sync.thor
@@ -155,7 +155,7 @@ class Sync < Thor
 
       # Check to see if we're already running:
       if daemon_running?
-        say_status 'warning', 'docker-sync already started for this configuration', :yellow
+        say_status 'ok:', 'docker-sync already started for this configuration', :white
         exit 0
       end
 


### PR DESCRIPTION
Closes: #621 -- `docker-sync` exists with non-zero exit code for properly started project