### PR TITLE
Fix logic for detecting brew unox installation

### DIFF
--- a/lib/docker-sync/dependencies/unox.rb
+++ b/lib/docker-sync/dependencies/unox.rb
@@ -14,9 +14,16 @@ module DockerSync
       def self.available?
         return @available if defined? @available
         cmd = 'brew list unox 2>&1 > /dev/null'
-        # TODO: Environment.linux?  was just a hotfix for something we did not dig deeper into, as we have should
-        # see https://github.com/EugenMayer/docker-sync/pull/630
-        @available = Environment.linux? or defined?(Bundler) ? Bundler.clean_system(cmd) : system(cmd)
+        # TODO: Environment.linux?  was just a hotfix for something we did not dig deeper into
+        # (as we have should) -- see https://github.com/EugenMayer/docker-sync/pull/630
+        if Environment.linux? then
+          @available = true
+        elsif defined?(Bundler) then
+          @available = Bundler.clean_system(cmd)
+        else
+          @available = system(cmd)
+        end
+        return @available
       end
 
       def self.ensure!


### PR DESCRIPTION
On my system docker-sync would fail to detect that unox was installed via brew without this fix-up.

Things I can think of that might be related: the system went through a recent Mojave upgrade (2 months) ago, more recently I did a mass "brew upgrade" to resolve an unrelated problem.

However most recently docker-sync prompted me to ugprade from 0.5.9 and 0.5.10-- after the upgrade this problem surfaced.  The problem didn't exist after the Mojave upgrade, but I'm unsure if the problem existed post "brew upgrade".

This PR seems to fix the issue, not sure if the logic is the same since I don't know Ruby.