### PR TITLE
allow to specific multiple time the sync_name when start

### DIFF
--- a/tasks/sync/sync.thor
+++ b/tasks/sync/sync.thor
@@ -155,8 +155,15 @@ class Sync < Thor
 
       # Check to see if we're already running:
       if daemon_running?
-        say_status 'ok:', 'docker-sync already started for this configuration', :white
-        exit 0
+        should_exit = true
+        unless options[:sync_name].empty?
+          running = `docker ps --filter 'status=running' --filter 'name=#{options[:sync_name]}' --format "{{.Names}}" | grep '^#{options[:sync_name]}$'`
+          should_exit = false if running == ''
+        end
+        if should_exit
+          say_status 'ok:', 'docker-sync already started for this configuration', :white
+          exit 0
+        end
       end
 
       # If we're daemonizing, run a sync first to ensure the containers exist so that a docker-compose up won't fail:


### PR DESCRIPTION
I'm using the same way as here to detect the sync container so that even the sync daemon is started, it is able to start
https://github.com/EugenMayer/docker-sync/blob/251f39113682cdd74b3bc882a794913ecb666fcb/lib/docker-sync/sync_strategy/native_osx.rb#L83

[![asciicast](https://asciinema.org/a/8JvhA89Q75NAS5Z7Q1oWKwOGm.svg)](https://asciinema.org/a/8JvhA89Q75NAS5Z7Q1oWKwOGm)

Two containers are being synced as normal
- app-one-sync
![image](https://user-images.githubusercontent.com/2409560/52045367-b7719e00-2587-11e9-81fa-e65ec4357581.png)
- app-two-sync
![image](https://user-images.githubusercontent.com/2409560/52045387-c22c3300-2587-11e9-9e5a-0fddb4c9b722.png)

Sorry my local environment cannot run the test so that I made the screencast.

Related to #618 