### PR TITLE
Add troubleshooting docs for sync stopping

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -12,7 +12,7 @@ help:
 	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
 
 livehtml:
-	sphinx-autobuild -b html "$(SOURCEDIR)" "$(BUILDDIR)/html" $(SPHINXOPTS) $(O)
+	sphinx-autobuild -E -b html "$(SOURCEDIR)" "$(BUILDDIR)/html" $(SPHINXOPTS) $(O)
 
 .PHONY: help livehtml Makefile
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,7 +4,7 @@ To re-generate the docs on your local machine, simply follow the commands below.
 
 ```shell
 # Install required dependencies
-pip install sphinx sphinx_rtd_theme
+pip install sphinx sphinx-autobuild sphinx_rtd_theme
 
 # Spins up the worker that will watch and re-generate the docs when changed
 make livehtml

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -26,9 +26,9 @@ copyright = '2019, Eugen Mayer'
 author = 'Eugen Mayer'
 
 # The short X.Y version
-version = '0.5.10'
+version = '0.5.11'
 # The full version, including alpha/beta/rc tags
-release = '0.5.10'
+release = '0.5.11'
 
 
 # -- General configuration ---------------------------------------------------

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -45,7 +45,6 @@ Features
    getting-started/installation
    getting-started/configuration
    getting-started/commands
-   getting-started/troubleshooting
    getting-started/upgrade
 
 .. toctree::
@@ -57,6 +56,14 @@ Features
    advanced/scripting
    advanced/how-it-works
    advanced/tips-and-tricks
+
+.. toctree::
+   :hidden:
+   :caption: Troubleshooting
+   :maxdepth: 2
+
+   troubleshooting/common-issues
+   troubleshooting/native-osx-troubleshooting
 
 .. toctree::
    :hidden:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -62,6 +62,7 @@ Features
    :caption: Troubleshooting
    :maxdepth: 2
 
+   troubleshooting/sync-stopping
    troubleshooting/common-issues
    troubleshooting/native-osx-troubleshooting
 

--- a/docs/troubleshooting/common-issues.rst
+++ b/docs/troubleshooting/common-issues.rst
@@ -1,0 +1,18 @@
+*******************
+Other common issues
+*******************
+
+Incorrect mount location
+========================
+
+Docker-sync uses a named container/volume for synchronizing. There is a chance you may have a conflicting sync name. To verify this, run:
+
+.. code-block:: shell
+
+    docker container inspect --format '{{(index .Mounts 1).Source}}' "$DEBUG_DOCKER_SYNC"
+
+If you do not see the path to your directory, this means your mount location is conflicting. To fix this issue:
+
+1. Bring your containers down
+2. Perform ``docker-sync clean``
+3. Bring your containers back up again.

--- a/docs/troubleshooting/native-osx-troubleshooting.rst
+++ b/docs/troubleshooting/native-osx-troubleshooting.rst
@@ -1,23 +1,19 @@
-***************
-Troubleshooting
-***************
-
-``native_osx`` strategy
-=======================
+****************************************************
+Advanced troubleshooting for ``native_osx`` strategy
+****************************************************
 
 .. note::
 
-    This document is a work in progress. Each time you encounter the scenario below, please revisit this document and [report any new findings](https://github.com/EugenMayer/docker-sync/issues/410).
+    This document is a work in progress. Each time you encounter the scenario below, please revisit this document and `report any new findings`_.
 
-Syncing stopped
-^^^^^^^^^^^^^^^
+.. _report any new findings: https://github.com/EugenMayer/docker-sync/issues/410
 
 The osx_native sync strategy is the fastest sync strategy for docker-sync under Docker4Mac. Unfortunately a recurring issue has emerged where the `sync strategy stops functioning`_. This page is to guide you on how to debug this situation to provide information so that it can be solved.
 
 .. _sync strategy stops functioning: https://github.com/EugenMayer/docker-sync/issues/410
 
-Prepare: Identify the docker-sync container involved
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Step 1 - Prepare: Identify the docker-sync container involved
+=============================================================
 
 First, open your docker-sync.yml file and find the sync that has to do with the code that appears to be failing to sync.
 
@@ -35,8 +31,8 @@ And your file that is not updating is under ``default-data``, then your sync nam
 
 Run this in your terminal (substitute in your sync name) for use in the remaining steps: ``DEBUG_DOCKER_SYNC='default-sync'``
 
-Prepare: A file path to check
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Step 2 - Prepare: A file path to check
+======================================
 
 Next we're going to assign a file path to a variable for use in the following steps.
 
@@ -44,8 +40,8 @@ Next we're going to assign a file path to a variable for use in the following st
 2. Prepare the relative path to your file that does not appear to be updating upon save, example ``some-dir/another-dir/my-file.ext``
 3. Run the following command with your path substituted in: ``DEBUG_DOCKER_FILE='some-dir/another-dir/my-file.ext'``
 
-Reproduction: Verify your host mount works (host_sync)
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Step 3 - Reproduction: Verify your host mount works (host_sync)
+===============================================================
 
 Run this to verify that your file changes have been synced by OSXFS to the sync-container
 
@@ -60,8 +56,8 @@ Usually this should never get broken at all, if it does, you see one of the foll
     Files some-dir/another-dir/my-file.ext and /dev/fd/63 differ
     diff: some-dir/another-dir/my-file.ext: No such file or directory
 
-Reproduction: Verify your changes have been sync by unison (app_sync)
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Step 4 - Reproduction: Verify your changes have been sync by unison (app_sync)
+==============================================================================
 
 Run this to verify that the changes have been sync from host_sync to app_sync on the container (using unison)
 
@@ -78,8 +74,8 @@ If you see a message one of the messages, this so called app_sync is broken:
 
 *If you do not see a message like one of these, then the issue you are encountering is not related to a sync failure and is probably something like caching or some other issue in your application stack, not docker-sync.*
 
-Reproduction: Unison log
-^^^^^^^^^^^^^^^^^^^^^^^^
+Step 5 - Reproduction: Unison log
+=================================
 
 If one of the upper errors occurred, please include the unison logs:
 
@@ -89,8 +85,8 @@ If one of the upper errors occurred, please include the unison logs:
 
 And paste those on Hastebin_ and include the link in your report
 
-Reproduction: Ensure you have no conflicts
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Step 6 - Reproduction: Ensure you have no conflicts
+===================================================
 
 Put that into your problematic sync container docker-sync.yml config:
 
@@ -117,27 +113,9 @@ And paste those on Hastebin_ and include the link in your report
 
 .. _Hastebin: https://hastebin.com
 
-If the debugging guide doesn't help yet...
-------------------------------------------
+Step 7 - Report the issue
+=========================
 
-Ensure your mount location is correct
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-Lastly, since docker-sync uses a named container/volume for synchronizing there is a chance you may have a conflicting sync name. To verify this is not the case run:
-
-.. code-block:: shell
-
-    docker container inspect --format '{{(index .Mounts 1).Source}}' "$DEBUG_DOCKER_SYNC"
-
-If see the path to your directory, continue.
-
-Otherwise, your mount is conflicting. You should bring your containers down and perform ``docker-sync clean`` before bringing your containers back up. The issue you encountered was not due to the scenario this debugging document is for.
-
-Debugging and reporting results
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-Perform the following, if you run into an error or unexpected result, report step you ran and the output of your error to `issue #410`_.
-
-- Run the whole guide with preparing and all Reproduction step, post the results under the specific header in `issue #410`_.
+If the issue still persists, post the results from the above steps in a new Github issue (see an example at `issue #410`)_.
 
 .. _issue #410: https://github.com/EugenMayer/docker-sync/issues/410

--- a/docs/troubleshooting/sync-stopping.rst
+++ b/docs/troubleshooting/sync-stopping.rst
@@ -1,0 +1,25 @@
+*************
+Sync stopping
+*************
+
+Npm / webpack / gulp based projects
+===================================
+
+Npm, webpack, gulp, and any other tooling that watches, deletes and/or creates a lot of files may cause sync to stop.
+
+In most cases, this has nothing to do with docker-sync at all, but with OSXFS getting stucked in the FS event queue, which then also stops events for unison in our docker image (linux, so inode events) and thus breaks syncing.
+
+- Run ``npm i``, ``composer install``, and the likes **before** ``docker-sync start``. This way we avoid tracking unnecessary FS events prior to start.
+
+- Sync only necessary folders, e.g. ``src/`` folders. Restructure your project layout if needed.
+
+
+Other reported solutions
+========================
+
+1. Run ``docker-sync stop && docker-sync start``
+2. Run ``docker-sync stop && docker-sync clean && docker-sync start``
+3. Manually going to the unison docker container and executing ``kill -1 [PID]`` on the unison process (`suggested by @grigoryosifov`_)
+4. Sometimes, the OSXFS itself gets stuck. Docker for Mac restart maybe the only option. Sometimes, an OS restart is the only option.
+
+.. _suggested by @grigoryosifov: https://github.com/EugenMayer/docker-sync/issues/646#issuecomment-466991460


### PR DESCRIPTION
I hope I'm not too late to the party...

RE: the suggestion to add a troubleshooting guide for sync stopping into the docs in https://github.com/EugenMayer/docker-sync/issues/646. Here is the PR.

The build: https://unnawut-docker-sync.readthedocs.io/en/docs-sync-stopping/

![image](https://user-images.githubusercontent.com/921194/63453341-a5e3db00-c472-11e9-8030-b3a07c4b7173.png)

