### PR TITLE
Address issue #695

### DIFF
--- a/tasks/sync/sync.thor
+++ b/tasks/sync/sync.thor
@@ -10,7 +10,7 @@ require 'timeout'
 class Sync < Thor
 
   class_option :config, :aliases => '-c',:default => nil, :type => :string, :desc => 'Path of the docker_sync config'
-  class_option :sync_name, :aliases => '-n',:type => :string, :desc => 'If given, only this sync configuration will be references/started/synced'
+  class_option :sync_name, :aliases => '-n',:default => '', :type => :string, :desc => 'If given, only this sync configuration will be references/started/synced'
   class_option :version, :aliases => '-v',:type => :boolean, :default => false, :desc => 'prints out the version of docker-sync and exits'
 
   desc '--version, -v', 'Prints out the version of docker-sync and exits'

--- a/tasks/sync/sync.thor
+++ b/tasks/sync/sync.thor
@@ -10,7 +10,7 @@ require 'timeout'
 class Sync < Thor
 
   class_option :config, :aliases => '-c',:default => nil, :type => :string, :desc => 'Path of the docker_sync config'
-  class_option :sync_name, :aliases => '-n',:default => '', :type => :string, :desc => 'If given, only this sync configuration will be references/started/synced'
+  class_option :sync_name, :aliases => '-n',:type => :string, :desc => 'If given, only this sync configuration will be references/started/synced'
   class_option :version, :aliases => '-v',:type => :boolean, :default => false, :desc => 'prints out the version of docker-sync and exits'
 
   desc '--version, -v', 'Prints out the version of docker-sync and exits'
@@ -156,7 +156,7 @@ class Sync < Thor
       # Check to see if we're already running:
       if daemon_running?
         should_exit = true
-        unless options[:sync_name].empty?
+        unless options[:sync_name].nil? || options[:sync_name].empty?
           running = `docker ps --filter 'status=running' --filter 'name=#{options[:sync_name]}' --format "{{.Names}}" | grep '^#{options[:sync_name]}$'`
           should_exit = false if running == ''
         end


### PR DESCRIPTION
Despite the `:sync_name` argument being configured as a string type, in Mac OS X / a few versions of Ruby reported, the argument's value gets interpreted as nil when not given on the command line.

~This sets the default for the argument to an empty string so that when `empty?` is passed to it, it won't produce `NoMethodError` the way it would for `nil`.~ Setting the default to an empty string causes other issues.

This modifies the condition statement where the exception was raised in issue #695  so that it short-circuits when the value is `nil`.