### PR TITLE
Add required version number to example

### DIFF
--- a/docs/getting-started/configuration.rst
+++ b/docs/getting-started/configuration.rst
@@ -30,6 +30,7 @@ References
 
 .. code-block:: yaml
 
+    version: "2"
     options:
       # default: docker-compose.yml if you like, you can set a custom location (path) of your compose file like ~/app/compose.yml
       # HINT: you can also use this as an array to define several compose files to include. Order is important!


### PR DESCRIPTION
Hi 👋 

Thanks for making and maintaining this project. While trying it for the first time I noticed that the documentation is not using the required version entry in the configuration file.

Hope this is useful for other people.