### PR TITLE
Fix wrong unison source path in unison strategy. Fixes #728

### DIFF
--- a/lib/docker-sync/sync_strategy/unison.rb
+++ b/lib/docker-sync/sync_strategy/unison.rb
@@ -204,7 +204,7 @@ module DockerSync
         say_status 'ok', "starting initial sync of #{container_name}", :white if @options['verbose']
         # wait until container is started, then sync:
         sync_host_port = get_host_port(get_container_name, UNISON_CONTAINER_PORT)
-        cmd = "unison -testserver #{@options['dest']} \"socket://#{@options['sync_host_ip']}:#{sync_host_port}\""
+        cmd = "unison -testserver #{@options['src']} \"socket://#{@options['sync_host_ip']}:#{sync_host_port}\""
         say_status 'command', cmd, :white if @options['verbose']
         attempt = 0
         max_attempt = @options['max_attempt'] || 5


### PR DESCRIPTION
Unison currently crashes with error "File monitoring helper program not running"
That happens because unox crashes with
```
[unox][DEBUG]: sendCmd: ERROR %5BErrno%202%5D%20No%20such%20file%20or%20directory%3A%20%27/app_sync/%27
```

Indeed, /app_sync is destination path in docker container, not source path on host

It should be like here https://github.com/EugenMayer/docker-sync/blob/2f3b65eaf236955b9a14f363b817f85b392422be/lib/docker-sync/sync_strategy/unison.rb#L120