### PR TITLE
Remove risky dependency availability memoizations

### DIFF
--- a/lib/docker-sync/dependencies/rsync.rb
+++ b/lib/docker-sync/dependencies/rsync.rb
@@ -2,8 +2,7 @@ module DockerSync
   module Dependencies
     module Rsync
       def self.available?
-        return @available if defined? @available
-        @available = find_executable0('rsync')
+        find_executable0('rsync')
       end
 
       def self.ensure!

--- a/lib/docker-sync/dependencies/unison.rb
+++ b/lib/docker-sync/dependencies/unison.rb
@@ -2,8 +2,7 @@ module DockerSync
   module Dependencies
     module Unison
       def self.available?
-        return @available if defined? @available
-        @available = find_executable0('unison')
+        find_executable0('unison')
       end
 
       def self.ensure!

--- a/lib/docker-sync/dependencies/unox.rb
+++ b/lib/docker-sync/dependencies/unox.rb
@@ -15,10 +15,8 @@ module DockerSync
         # should never have been called anyway - fix the call that it should check for the OS
         raise 'Unox cannot be available for other platforms then MacOS' unless Environment.mac?
 
-        return @available if defined? @available
         cmd = 'brew list unox 2>&1 > /dev/null'
-        @available = Environment.system(cmd)
-        @available
+        Environment.system(cmd)
       end
 
       def self.ensure!


### PR DESCRIPTION
I've removed memoization of availability check of dependencies that docker-sync likes to install. This is because it's very easy to get in a loop of: Check? No? Install. Check? Still no? Install. This happens for example with unison, as this check is called twice, even though docker-sync installed it in between.

I would prefer to remove this memoization from every dependency class, even the ones where we don't install anything, but I didn't want to do more invasive changes as I'm not familiar with project enough.

Specifically, what made me do this is is following issue:
```
$ docker-sync-stack start
     warning  Could not find unison. Trying to install it now.
Install unison for you? [y/N] y
     command  brew install unison
Updating Homebrew...
==> Downloading https://homebrew.bintray.com/bottles/unison-2.51.2.catalina.bottle.1.tar.gz
Already downloaded: /Users/gostrolucky/Library/Caches/Homebrew/downloads/460620e4ad590448905943f8d7b4e647ab7ffcf472c0704106e5e4debc029070--unison-2.51.2.catalina.bottle.1.tar.gz
==> Pouring unison-2.51.2.catalina.bottle.1.tar.gz
🍺  /usr/local/Cellar/unison/2.51.2: 9 files, 3.5MB
       note:  You can also run docker-sync in the background with docker-sync start
     warning  Could not find unison. Trying to install it now.
Install unison for you? [y/N]
```