### PR TITLE
Fix invalid stderr silencing syntax

### DIFF
--- a/lib/docker-sync/dependencies/docker.rb
+++ b/lib/docker-sync/dependencies/docker.rb
@@ -11,7 +11,7 @@ module DockerSync
 
       def self.running?
         return @running if defined? @running
-        @running = system('docker ps 2>&1 > /dev/null')
+        @running = system('docker ps > /dev/null 2>&1')
       end
 
       def self.ensure!

--- a/lib/docker-sync/dependencies/unox.rb
+++ b/lib/docker-sync/dependencies/unox.rb
@@ -15,7 +15,7 @@ module DockerSync
         # should never have been called anyway - fix the call that it should check for the OS
         raise 'Unox cannot be available for other platforms then MacOS' unless Environment.mac?
 
-        cmd = 'brew list unox 2>&1 > /dev/null'
+        cmd = 'brew list unox > /dev/null 2>&1'
         Environment.system(cmd)
       end
 

--- a/spec/integration/native-osx_strategy_spec.rb
+++ b/spec/integration/native-osx_strategy_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe 'native_osx strategy', command_execution: :allowed, if: OS.mac? d
 
   before :all do
     # Cleanup potentially leftover container from previously killed test suite
-    system('docker rm -f -v docker_sync_specs-sync 2>&1 > /dev/null')
+    system('docker rm -f -v docker_sync_specs-sync > /dev/null 2>&1')
   end
 
   describe 'start' do


### PR DESCRIPTION
I don't think these ever worked. This PR fixes this and uses same syntax now like [has_internet check in update_check.rb](https://github.com/EugenMayer/docker-sync/blob/21c649fa8d23b3692ae59231622bafc348f3376b/lib/docker-sync/update_check.rb#L41), which is correct. I've verified change of syntax still works across various shells and demonstrated below:

```
➜  ~ /bin/bash --version
GNU bash, version 3.2.57(1)-release (x86_64-apple-darwin19)
Copyright (C) 2007 Free Software Foundation, Inc.
➜  ~ /bin/bash -c 'brew list unox 2>&1 > /dev/null'
Error: No such keg: /usr/local/Cellar/unox
➜  ~ /bin/bash -c 'brew list unox > /dev/null 2>&1'
➜  ~ /usr/local/bin/bash --version
GNU bash, version 5.0.16(1)-release (x86_64-apple-darwin19.3.0)
Copyright (C) 2019 Free Software Foundation, Inc.
License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>

This is free software; you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.
➜  ~ /usr/local/bin/bash -c 'brew list unox 2>&1 > /dev/null'
Error: No such keg: /usr/local/Cellar/unox
➜  ~ /usr/local/bin/bash -c 'brew list unox > /dev/null 2>&1'
➜  ~ /usr/local/bin/zsh --version
zsh 5.8 (x86_64-apple-darwin19.3.0)
➜  ~ zsh -c 'brew list unox 2>&1 > /dev/null'
Error: No such keg: /usr/local/Cellar/unox
➜  ~ zsh -c 'brew list unox > /dev/null 2>&1'
➜  ~ brew list unox > /dev/null 2>&1
➜  ~ echo $?
1
➜  ~ brew install eugenmayer/dockersync/unox
==> Installing unox from eugenmayer/dockersync
==> Downloading https://github.com/hnsl/unox/archive/0.2.0.tar.gz
Already downloaded: /Users/gostrolucky/Library/Caches/Homebrew/downloads/b2503a5e57457fddcbad2f236a6df2107425dec0ebbf983599a6429f3a5c2f9c--unox-0.2.0.tar.gz
==> Downloading https://files.pythonhosted.org/packages/11/74/2c151a13ef41ab9fb43b3c4ff9e788e0496ed7923b2078d42cab30622bdf/virtualenv-16.7.4.tar.gz
Already downloaded: /Users/gostrolucky/Library/Caches/Homebrew/downloads/507d2087bf24df82641b681a5fe4da778ef50ebe819a86ea1b584f70788f0f63--virtualenv-16.7.4.tar.gz
==> python3 -c import setuptools... --no-user-cfg install --prefix=/private/tmp/unox--homebrew-virtualenv-20200424-69344-wz8sdt/target --install-scripts=/private/tmp/unox--homebrew-virtualenv-2020
==> python3 -s /private/tmp/unox--homebrew-virtualenv-20200424-69344-wz8sdt/target/bin/virtualenv -p python3 /usr/local/Cellar/unox/0.2.0_1/libexec
==> Downloading https://pypi.python.org/packages/54/7d/c7c0ad1e32b9f132075967fc353a244eb2b375a3d2f5b0ce612fd96e107e/watchdog-0.8.3.tar.gz
Already downloaded: /Users/gostrolucky/Library/Caches/Homebrew/downloads/0d36ce03441bcacec64a81693c6e6cf57ad7388e517415dc3b7512dedf057c03--watchdog-0.8.3.tar.gz
==> /usr/local/Cellar/unox/0.2.0_1/libexec/bin/pip install -v --no-deps --no-binary :all: --ignore-installed /private/tmp/unox--watchdog-20200424-69344-weyhfw/watchdog-0.8.3
==> Downloading https://pypi.python.org/packages/e7/7f/470d6fcdf23f9f3518f6b0b76be9df16dcc8630ad409947f8be2eb0ed13a/pathtools-0.1.2.tar.gz
Already downloaded: /Users/gostrolucky/Library/Caches/Homebrew/downloads/0f7b6eac9aedf76318368c0c3b8cc98e75adbf403b4b1de98260fd84815b31f3--pathtools-0.1.2.tar.gz
==> /usr/local/Cellar/unox/0.2.0_1/libexec/bin/pip install -v --no-deps --no-binary :all: --ignore-installed /private/tmp/unox--pathtools-20200424-69344-utc0zs/pathtools-0.1.2
==> /usr/local/Cellar/unox/0.2.0_1/libexec/bin/pip install -v --no-deps --no-binary :all: --ignore-installed /private/tmp/unox-20200424-69344-95oss2/unox-0.2.0
🍺  /usr/local/Cellar/unox/0.2.0_1: 1,134 files, 11.2MB, built in 13 seconds
➜  ~ brew list unox > /dev/null 2>&1
➜  ~ echo $?
0
➜  ~
```