### PR TITLE
Make docker-sync consistently find docker-sync.yml from subfolders

### DIFF
--- a/lib/docker-sync/config/config_locator.rb
+++ b/lib/docker-sync/config/config_locator.rb
@@ -16,6 +16,11 @@ module DockerSync
         path
       end
 
+      # @return [String] the path to directory where project configuration file is found
+      def lookup_project_config_dir
+        File.dirname(lookup_project_config_path)
+      end
+
       # @return [String] the path to the project configuration found
       def lookup_project_config_path
         files = project_config_find

--- a/lib/docker-sync/config/project_config.rb
+++ b/lib/docker-sync/config/project_config.rb
@@ -117,7 +117,7 @@ module DockerSync
           'sync_strategy' => sync_strategy_for(sync_config),
           'watch_strategy' => watch_strategy_for(sync_config)
         }.merge(sync_config).merge(
-          'src' => expand_path(sync_config['src']),
+          'src' => expand_path(DockerSync::ConfigLocator.lookup_project_config_dir + '/' + sync_config['src']),
         )
       end
 


### PR DESCRIPTION
Aim of this is to make all commands working even when docker-sync.yml is not in current dir, but in one of the children

Fixes #729