### PR TITLE
Use COMPOSE_FILE to set default compose file

### DIFF
--- a/lib/docker-sync/compose.rb
+++ b/lib/docker-sync/compose.rb
@@ -8,7 +8,10 @@ class ComposeManager
     @global_options = global_options
 
     ### production docker-compose.yml
-    compose_files = [File.expand_path('docker-compose.yml')]
+    compose_files = DockerSync::Environment.compose_file.map do |f|
+      File.expand_path(f)
+    end
+    
     if @global_options.key?('compose-file-path')
       compose_files = [] # replace
       apply_path_settings(compose_files, @global_options['compose-file-path'], 'compose-file-path')

--- a/lib/docker-sync/environment.rb
+++ b/lib/docker-sync/environment.rb
@@ -19,5 +19,13 @@ module DockerSync
     def self.system(cmd)
       defined?(Bundler) ? Bundler.clean_system(cmd) : Kernel.system(cmd)
     end
+
+    def self.compose_file
+      if ENV['COMPOSE_FILE']
+        ENV['COMPOSE_FILE'].split(/[:;]/)
+      else
+        ["docker-compose.yml"]
+      end
+    end
   end
 end

--- a/spec/lib/docker-sync/environment_spec.rb
+++ b/spec/lib/docker-sync/environment_spec.rb
@@ -1,0 +1,46 @@
+require_relative "../../../lib/docker-sync/environment"
+
+RSpec.describe DockerSync::Environment do
+  describe :compose_file do
+    def mock_compose_env(value)
+      allow(ENV).to receive(:[]).with("COMPOSE_FILE").and_return(value)
+    end
+
+    it "should have the correct default" do
+      mock_compose_env(nil)
+
+      result = DockerSync::Environment.compose_file
+
+      expect(result).to eq(['docker-compose.yml'])
+    end
+
+    it "respects ENV['COMPOSE_FILE']" do
+      mock_compose_env('other-compose.yml')
+
+      result = DockerSync::Environment.compose_file
+
+      expect(result).to eq(['other-compose.yml'])
+    end
+
+    it "handles multiple files" do
+      mock_compose_env('first-compose.yml:second-compose.yml')
+
+      result = DockerSync::Environment.compose_file
+
+      expect(result).to eq([
+        'first-compose.yml',
+        'second-compose.yml'
+      ])
+    end
+    it "handles multiple files with semi-colon" do
+      mock_compose_env('first-compose.yml;second-compose.yml')
+
+      result = DockerSync::Environment.compose_file
+
+      expect(result).to eq([
+        'first-compose.yml',
+        'second-compose.yml'
+      ])
+    end
+  end
+end


### PR DESCRIPTION
docker-compose allows the `COMPOSE_FILE` environment variable to control the docker-compose file:

https://docs.docker.com/compose/reference/envvars/#compose_file

This PR updates docker-sync to also use `COMPOSE_FILE`