### PR TITLE
Detect docker host OS

### DIFF
--- a/lib/docker-sync/dependencies/docker_driver.rb
+++ b/lib/docker-sync/dependencies/docker_driver.rb
@@ -12,7 +12,7 @@ module DockerSync
           return false unless Environment.mac? || Environment.freebsd?
           return false unless find_executable0('docker-machine')
           return @docker_toolbox if defined? @docker_toolbox
-          @docker_toolbox = Environment.system('docker info | grep -q "Operating System: Boot2Docker"')
+          @docker_toolbox = Environment.system('docker info | grep -q -E "Operating System: {1,}"')
         end
       end
     end

--- a/spec/lib/docker-sync/dependencies/docker_driver_spec.rb
+++ b/spec/lib/docker-sync/dependencies/docker_driver_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe DockerSync::Dependencies::Docker::Driver do
 
     it 'checks if Docker is running in Boot2Docker' do
       subject
-      expect(DockerSync::Environment).to have_received(:system).with('docker info | grep -q "Operating System: Boot2Docker"')
+      expect(DockerSync::Environment).to have_received(:system).with('docker info | grep -q -E "Operating System: {1,}"')
     end
 
     it 'is memoized' do


### PR DESCRIPTION
👋 @EugenMayer. Thank you for this app

I have an external machine in the docker-machine. docker-sync works with it only if specify the address:
```
sync_host_ip = 91.117.201.122
```
`sync_host_ip = 'auto'` doesn't work because of my docker host OS is `Ubuntu 18.04.4 LTS`
I have a `macOS` and `docker toolbox` installed there.

My PR checks that the OS docker exists. Not only `Boot2Docker`

I will be glad to answer your questions 