### PR TITLE
Update link in message regarding `dest` removal

### DIFF
--- a/lib/docker-sync/sync_manager.rb
+++ b/lib/docker-sync/sync_manager.rb
@@ -48,7 +48,7 @@ module DockerSync
         end
 
         if @config_syncs[name].key?('dest')
-          puts 'Please do no longer use "dest" in your docker-sync.yml configuration - also see https://github.com/EugenMayer/docker-sync/wiki/1.2-Upgrade-Guide#dest-has-been-removed!'
+          puts 'Please do no longer use "dest" in your docker-sync.yml configuration - also see https://docker-sync.readthedocs.io/en/latest/getting-started/upgrade.html#id4'
           exit 1
         else
           @config_syncs[name]['dest'] = '/app_sync'


### PR DESCRIPTION
When a value for `dest` is set, a message is displayed informing that it has been removed. This message contains a link pointing to wiki as a reference. This link is outdated though.

This commit replaces the outdated link with a link to the same section in the docs that are currently being used (readthedocs).