### PR TITLE
Fix test specs

### DIFF
--- a/spec/integration/native-osx_strategy_spec.rb
+++ b/spec/integration/native-osx_strategy_spec.rb
@@ -7,11 +7,12 @@ RSpec.describe 'native_osx strategy', command_execution: :allowed, if: OS.mac? d
   include Rspec::Bash
 
   let(:env)                  { create_stubbed_env }
+  let(:dir)                  { Dir.tmpdir }
   let(:bin)                  { File.expand_path(File.join(__dir__, '..', '..', 'bin', 'docker-sync')) }
   let(:config_file_template) { File.expand_path(File.join(__dir__, '..', '..', 'spec', 'fixtures', 'native_osx', 'docker-sync.yml')) }
-  let(:config_file_path)     { File.join(env.dir, 'docker-sync.yml') }
+  let(:config_file_path)     { File.join(dir, 'docker-sync.yml') }
   let(:host_app_template)    { 'spec/fixtures/app_skeleton' }
-  let(:host_app_path)        { File.join(env.dir, File.basename(host_app_template)) }
+  let(:host_app_path)        { File.join(dir, File.basename(host_app_template)) }
   let(:test_env_vars)        { { 'DOCKER_SYNC_SKIP_UPGRADE' => 'true', 'DOCKER_SYNC_SKIP_UPDATE' => 'true', 'DOCKER_SYNC_SKIP_DEPENDENCIES_CHECK' => 'true' } }
 
   before :all do
@@ -21,8 +22,8 @@ RSpec.describe 'native_osx strategy', command_execution: :allowed, if: OS.mac? d
 
   describe 'start' do
     around(:each) do |example|
-      FileUtils.cp_r([host_app_template, config_file_template], env.dir)
-      FileUtils.chdir(env.dir) do
+      FileUtils.cp_r([host_app_template, config_file_template], dir)
+      FileUtils.chdir(dir) do
         replace_in_file(config_file_path, '{{HOST_APP_PATH}}', "'#{host_app_path}'")
         _stdout, stderr, status = env.execute_inline("#{bin} start", test_env_vars)
         raise stderr unless status.success?

--- a/spec/lib/docker-sync/project_config_spec.rb
+++ b/spec/lib/docker-sync/project_config_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe DockerSync::ProjectConfig do
 
   subject { described_class.new }
   before do
-    allow(DockerSync::Dependencies::Docker::Driver).to receive(:system).with('pgrep -q com.docker.hyperkit').and_return(true)
+    allow(DockerSync::Environment).to receive(:system).with('pgrep -q com.docker.hyperkit').and_return(true)
   end
 
   describe '#initialize' do


### PR DESCRIPTION
Fixes spec failures that I found when pulling down `master` on macOS, perhaps other envs too.

1. Use `Dir.tmpdir` instead of the `rspec-bash`'s `create_stubbed_env` `#dir` method, which does not seem to exist anymore?
2. There seemed to be an invalid stubbing of the executor methods. The code uses `DockerSync::Environment.system`, but the spec expected it to be `DockerSync::Dependencies::Docker::Driver.system`
3. Added more `OS` conditions for detecting `.mac?`, since `.linux?` did not capture it.

```
 Failure/Error: FileUtils.cp_r([host_app_template, config_file_template], env.dir)

      NoMethodError:
        undefined method `dir' for #<Rspec::Bash::StubbedEnv:0x00007fb0eeaf9988>
      Shared Example Group: "a synchronized directory" called from ./spec/integration/native-osx_strategy_spec.rb:43
      # ./spec/integration/native-osx_strategy_spec.rb:24:in `block (3 levels) in <top (required)>'

 CommandExecutionMock::CommandExecutionNotAllowed:
        Command execution is not allowed. Please stub the following call: __system_without_any_instance__("pgrep -q com.docker.hyperkit")
      # ./spec/helpers/command_mocking_helpers.rb:36:in `block in stub_command_executor'
      # ./lib/docker-sync/environment.rb:22:in `system'
```