### PR TITLE
Add support for sync failure notification via notify_terminal_error

### DIFF
--- a/docs/getting-started/configuration.rst
+++ b/docs/getting-started/configuration.rst
@@ -386,14 +386,12 @@ notify_terminal
 Type:
   optional
 
-Enable terminal_notifier.
 On every sync sends a Terminal Notification regarding files being synced.
 (Mac Only).
 
-Good thing in case you are developing and want to know exactly when your
-changes took effect.
-Be aware in case of unison this only gives you a notification on the initial sync,
-not the syncs after changes.
+Useful for when you want to know exactly when your changes took effect (or failed to do so).
+Be aware that in case of unison this only gives you a notification on the initial sync,
+not on syncs after subsequent changes.
 
 default:
   ``false``
@@ -403,6 +401,7 @@ Options                       Description
 ==========================    ===============
 ``false``
 ``true``                      Show notifications
+``errors_only``               Show only error notifications
 ==========================    ===============
 
 

--- a/example/docker-sync.yml
+++ b/example/docker-sync.yml
@@ -78,7 +78,7 @@ syncs:
     sync_prefer: 'default'
 
   rsync-sync: # IMPORTANT: this name must be unique and should NOT match your real application container name!
-    # enable terminal_notifier. On every sync sends a Terminal Notification regarding files being synced. ( Mac Only ).
+    # On every sync sends a Terminal Notification regarding files being synced. ( Mac Only ).
     # good thing incase you are developing and want to know exactly when your changes took effect.
     notify_terminal: true
     # which folder to watch / sync from - you can use tilde, it will get expanded.

--- a/lib/docker-sync/sync_strategy/rsync.rb
+++ b/lib/docker-sync/sync_strategy/rsync.rb
@@ -42,12 +42,16 @@ module DockerSync
 
         out = `#{cmd}`
         if $?.exitstatus > 0
-          say_status 'error', "Error starting sync, exit code #{$?.exitstatus}", :red
+          error_msg = "Error starting sync, exit code #{$?.exitstatus}"
+          say_status 'error', error_msg, :red
           say_status 'message', out
+          TerminalNotifier.notify(
+            "#{error_msg}", :title => @sync_name, :subtitle => @options['src'], group: 'docker-sync'
+          ) if @options['notify_terminal']
         else
           TerminalNotifier.notify(
-            "Synced #{@options['src']}", :title => @sync_name
-          ) if @options['notify_terminal']
+            "Synced #{@options['src']}", :title => @sync_name, group: 'docker-sync'
+          ) if @options['notify_terminal'] && @options['notify_terminal'] != 'errors_only'
           say_status 'ok', "Synced #{@options['src']}", :white
           if @options['verbose']
             say_status 'output', out

--- a/lib/docker-sync/sync_strategy/unison.rb
+++ b/lib/docker-sync/sync_strategy/unison.rb
@@ -78,13 +78,20 @@ module DockerSync
 
         stdout, stderr, exit_status = Open3.capture3(cmd)
         if !exit_status.success?
-          say_status 'error', "Error starting sync, exit code #{$?.exitstatus}", :red
+          error_msg = "Error starting sync, exit code #{$?.exitstatus}"
+          say_status 'error', error_msg, :red
           say_status 'message', stdout
           say_status 'message', stderr
-        else
+
           if @options['notify_terminal']
             TerminalNotifier.notify(
-              "Synced #{@options['src']}", title: @sync_name
+              "#{error_msg}", :title => @sync_name, :subtitle => @options['src'], group: 'docker-sync'
+            )
+          end
+        else
+          if @options['notify_terminal'] && @options['notify_terminal'] != 'errors_only'
+            TerminalNotifier.notify(
+              "Synced #{@options['src']}", title: @sync_name, group: 'docker-sync'
             )
           end
           say_status 'ok', "Synced #{@options['src']}", :white


### PR DESCRIPTION
First off, thanks for this amazing tool! 🙏 We've utilized `docker-sync` extensively across our RoR codebases for a few years now.

Proposing to add `notify_terminal_error` (same as the existing `notify_terminal` option but for errors) to provide the user a visual cue when `docker-sync` might have stopped syncing (e.g. after restarting Docker Desktop).

Example:

<img width="370" alt="Screen Shot 2021-10-25 at 15 25 21" src="https://user-images.githubusercontent.com/1456748/138698520-e9b4caa5-ec5e-4852-9b39-0351b441e534.png">

...sync container name being `sync-login` with source directory `/Users/make/Documents/login`.