### PR TITLE
Detect new Virtualization framework under macOS

### DIFF
--- a/lib/docker-sync/dependencies/docker_driver.rb
+++ b/lib/docker-sync/dependencies/docker_driver.rb
@@ -5,6 +5,10 @@ module DockerSync
         def self.docker_for_mac?
           return false unless Environment.mac?
           return @docker_for_mac if defined? @docker_for_mac
+
+          # com.docker.hyperkit for old virtualization engine
+          # com.docker.virtualization for new virtualization engine
+          # see https://docs.docker.com/desktop/mac/#enable-the-new-apple-virtualization-framework
           @docker_for_mac = Environment.system('pgrep -q com.docker.hyperkit') || Environment.system('pgrep -q com.docker.virtualization')
         end
 

--- a/lib/docker-sync/dependencies/docker_driver.rb
+++ b/lib/docker-sync/dependencies/docker_driver.rb
@@ -5,7 +5,7 @@ module DockerSync
         def self.docker_for_mac?
           return false unless Environment.mac?
           return @docker_for_mac if defined? @docker_for_mac
-          @docker_for_mac = Environment.system('pgrep -q com.docker.hyperkit')
+          @docker_for_mac = Environment.system('pgrep -q com.docker.hyperkit') || Environment.system('pgrep -q com.docker.virtualization')
         end
 
         def self.docker_toolbox?

--- a/spec/lib/docker-sync/dependencies/docker_driver_spec.rb
+++ b/spec/lib/docker-sync/dependencies/docker_driver_spec.rb
@@ -25,6 +25,15 @@ RSpec.describe DockerSync::Dependencies::Docker::Driver do
       expect(DockerSync::Environment).to have_received(:system).with('pgrep -q com.docker.hyperkit')
     end
 
+    it 'checks if Docker is running in Virtualization' do
+      allow(DockerSync::Environment).to receive(:system).with('pgrep -q com.docker.hyperkit').and_return(false)
+      allow(DockerSync::Environment).to receive(:system).with('pgrep -q com.docker.virtualization').and_return(true)
+
+      is_expected.to be true
+      expect(DockerSync::Environment).to have_received(:system).with('pgrep -q com.docker.hyperkit')
+      expect(DockerSync::Environment).to have_received(:system).with('pgrep -q com.docker.virtualization')
+    end
+
     it 'is memoized' do
       expect { 1.times { described_class.docker_for_mac? } }.to change { described_class.instance_variable_defined?(:@docker_for_mac) }
 


### PR DESCRIPTION
Context: https://github.com/EugenMayer/docker-sync/issues/799

Check `com.docker.virtualization` process name in `.docker_for_mac?` for new Virtualization framework. Which effect default sync strategy in mac. Without this patch, docker-sync will use unison instead of native_osx.

I use in my project, looks work:

```
$ docker-sync start
          ok  Starting native_osx for sync geeknote-sync
geeknote-sync
unison: stopped
unison: started
     success  Sync container started
     success  Starting Docker-Sync in the background
```

Edit some file:

```
$ docker logs -f geeknote-sync
Looking for changes
Reconciling changes
changed  ---->            app/views/posts/index.html.erb  
Propagating updates
UNISON 2.51.3 (OCAML 4.12.0) started propagating changes at 15:40:16.22 on 06 May 2022
[BGN] Updating file app/views/posts/index.html.erb from /host_sync to /app_sync
[END] Updating file app/views/posts/index.html.erb
UNISON 2.51.3 (OCAML 4.12.0) finished propagating changes at 15:40:16.26 on 06 May 2022
Saving synchronizer state
Synchronization complete at 15:40:16  (1 item transferred, 0 skipped, 0 failed)
Looking for changes
Reconciling changes
Nothing to do: replicas have not changed since last sync.
```

But I'm not very clear about the internals of docker-sync, maybe need more test that native_osx strategy works fine on new Virtualization framework. 