### PR TITLE
Fix unison image architecture

### DIFF
--- a/lib/docker-sync/sync_strategy/native_osx.rb
+++ b/lib/docker-sync/sync_strategy/native_osx.rb
@@ -23,7 +23,11 @@ module DockerSync
         if @options.key?('image')
           @docker_image = @options['image']
         else
-          @docker_image = 'eugenmayer/unison:2.51.3-4.12.0-AMD64'
+          if RUBY_PLATFORM.include? "arm"
+            @docker_image = 'eugenmayer/unison:2.51.3-4.12.0-ARM64'
+          else
+            @docker_image = 'eugenmayer/unison:2.51.3-4.12.0-AMD64'
+          end
         end
 
         begin

--- a/lib/docker-sync/sync_strategy/unison.rb
+++ b/lib/docker-sync/sync_strategy/unison.rb
@@ -22,7 +22,11 @@ module DockerSync
         @docker_image = if @options.key?('image')
                           @options['image']
                         else
-                          'eugenmayer/unison:2.51.3-4.12.0-AMD64'
+                          if RUBY_PLATFORM.include? "arm"
+                            'eugenmayer/unison:2.51.3-4.12.0-ARM64'
+                          else
+                            'eugenmayer/unison:2.51.3-4.12.0-AMD64'
+                          end
                         end
         begin
           Dependencies::Unison.ensure!


### PR DESCRIPTION
The current docker-sync will always pull the AMD unison image, even when running on ARM systems.

To fix this we can set the default unison image tag based on the architecture of the platform with the `RUBY_PLATFORM` constant.