### PR TITLE
Migrate to new unison images fixes #810

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_3" project-jdk-name="ruby2.5" project-jdk-type="RUBY_SDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_3" project-jdk-name="rbenv: 2.7.5" project-jdk-type="RUBY_SDK">
     <output url="file://$PROJECT_DIR$/out" />
   </component>
   <component name="ProjectType">

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ os: linux
 rvm:
   - 2.4
   - 2.7
+  - 3.0
 
 #os: osx
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,9 +15,15 @@ os:
 
 services: docker
 
+jobs:
+  exclude:
+    # does not work - rvm cannot install ruby
+    - rvm: 3.1.2
+      arch: arm64
+
 before_install:
   - gem install bundler:2.2.15
-  - docker pull ghcr.io/eugenmayer/unison:2.52.1-4.12.0
-  - docker pull eugenmayer/rsync
+#  - docker pull ghcr.io/eugenmayer/unison:2.52.1-4.12.0
+#  - docker pull eugenmayer/rsync
 
 script: bundle exec rspec --format=documentation

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ services: docker
 
 jobs:
   exclude:
-    # does not work - rvm cannot install ruby
+    # does not work - rvm cannot install ruby 3.x under arm64 (not investigated further)
     - rvm: 3.1.2
       arch: arm64
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,8 +16,7 @@ services: docker
 
 before_install:
   - gem install bundler:2.2.15
-  - docker pull eugenmayer/unison:2.51.3-4.12.0-AMD64
-  - docker pull eugenmayer/unison:2.51.3-4.12.0-ARM64
+  - docker pull ghcr.io/eugenmayer/unison:2.52.1-4.12.0
   - docker pull eugenmayer/rsync
 
 script: bundle exec rspec --format=documentation

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,8 @@ rvm:
 
 os:
   - linux
-  - osx
+  # since there is no docker support due to license issues under OSX, running there does not make any sense
+  # - osx
 
 services: docker
 
@@ -21,9 +22,13 @@ jobs:
     - rvm: 3.1.2
       arch: arm64
 
+    # ruby 3 somehow cannot be installed on osx either
+    - rvm: 3.1.2
+      os: osx
+
 before_install:
   - gem install bundler:2.2.15
-#  - docker pull ghcr.io/eugenmayer/unison:2.52.1-4.12.0
-#  - docker pull eugenmayer/rsync
+  - docker pull ghcr.io/eugenmayer/unison:2.52.1-4.12.0
+  - docker pull eugenmayer/rsync
 
 script: bundle exec rspec --format=documentation

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,14 +4,14 @@ arch:
   - amd64
   - arm64
 
-os: linux
-
 rvm:
   - 2.4
   - 2.7
-  - 3.0
+  - 3.1.2
 
-#os: osx
+os:
+  - linux
+  - osx
 
 services: docker
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -55,6 +55,7 @@ GEM
 
 PLATFORMS
   aarch64-linux
+  x86_64-darwin-17
   x86_64-linux
 
 DEPENDENCIES
@@ -66,4 +67,4 @@ DEPENDENCIES
   rspec-bash
 
 BUNDLED WITH
-   2.3.13
+   2.3.21

--- a/docs/getting-started/installation.rst
+++ b/docs/getting-started/installation.rst
@@ -232,7 +232,7 @@ Then type the following command in your WSL shell.
 
 9. Compile and install OCaml
 
-Before doing this please check out first the eugenmayer/unison dockerfile and ensure that the OCaml version that you are going to install is the same. To find the required OCaml version, do a search for "ocaml" within the eugenmayer/unison's dockerfile (https://github.com/EugenMayer/docker-image-unison/blob/master/Dockerfile)
+Before doing this please check out first the ghcr.io/eugenmayer/unison dockerfile and ensure that the OCaml version that you are going to install is the same. To find the required OCaml version, do a search for "ocaml" within the eugenmayer/unison's dockerfile (https://github.com/EugenMayer/docker-image-unison/blob/master/Dockerfile)
 
 Install build script
 

--- a/lib/docker-sync/sync_strategy/native_osx.rb
+++ b/lib/docker-sync/sync_strategy/native_osx.rb
@@ -20,7 +20,7 @@ module DockerSync
         @options = options
         @sync_name = sync_name
         # if a custom image is set, apply it
-        @docker_image = @options.key?('image') ? @options['image'] : 'eugenmayer/unison:2.52.1-4.12.0'
+        @docker_image = @options.key?('image') ? @options['image'] : 'ghcr.io/eugenmayer/unison:2.52.1-4.12.0'
 
         begin
           Dependencies::Docker.ensure!

--- a/lib/docker-sync/sync_strategy/native_osx.rb
+++ b/lib/docker-sync/sync_strategy/native_osx.rb
@@ -20,11 +20,7 @@ module DockerSync
         @options = options
         @sync_name = sync_name
         # if a custom image is set, apply it
-        if @options.key?('image')
-          @docker_image = @options['image']
-        else
-          @docker_image = 'eugenmayer/unison:2.51.3-4.12.0-AMD64'
-        end
+        @docker_image = @options.key?('image') ? @options['image'] : 'eugenmayer/unison:2.52.1-4.12.0'
 
         begin
           Dependencies::Docker.ensure!

--- a/lib/docker-sync/sync_strategy/unison.rb
+++ b/lib/docker-sync/sync_strategy/unison.rb
@@ -19,7 +19,7 @@ module DockerSync
         @options = options
         @sync_name = sync_name
         # if a custom image is set, apply it
-        @docker_image = @options.key?('image') ? @options['image'] :  'eugenmayer/unison:2.52.1-4.12.0'
+        @docker_image = @options.key?('image') ? @options['image'] :  'ghcr.io/eugenmayer/unison:2.52.1-4.12.0'
         begin
           Dependencies::Unison.ensure!
           Dependencies::Unox.ensure! if Environment.mac?

--- a/lib/docker-sync/sync_strategy/unison.rb
+++ b/lib/docker-sync/sync_strategy/unison.rb
@@ -19,11 +19,7 @@ module DockerSync
         @options = options
         @sync_name = sync_name
         # if a custom image is set, apply it
-        @docker_image = if @options.key?('image')
-                          @options['image']
-                        else
-                          'eugenmayer/unison:2.51.3-4.12.0-AMD64'
-                        end
+        @docker_image = @options.key?('image') ? @options['image'] :  'eugenmayer/unison:2.52.1-4.12.0'
         begin
           Dependencies::Unison.ensure!
           Dependencies::Unox.ensure! if Environment.mac?

--- a/lib/docker-sync/update_check.rb
+++ b/lib/docker-sync/update_check.rb
@@ -4,8 +4,6 @@ require 'docker-sync/config/global_config'
 
 class UpdateChecker
   include Thor::Shell
-  @config
-  @newer_image_found
 
   def initialize
     @config = DockerSync::GlobalConfig.load

--- a/lib/docker-sync/upgrade_check.rb
+++ b/lib/docker-sync/upgrade_check.rb
@@ -5,7 +5,6 @@ require 'docker-sync/update_check'
 
 class UpgradeChecker
   include Thor::Shell
-  @config
   def initialize
     @config = DockerSync::GlobalConfig.load
   end


### PR DESCRIPTION
Migrate to new unison images which are build for amd64/arm64 using manifests. This will fix #810 

- add ruby 3.0 to test matrix