### PR TITLE
Fix sync_prefer dest (sync_host_port not defined)

### DIFF
--- a/lib/docker-sync/sync_strategy/unison.rb
+++ b/lib/docker-sync/sync_strategy/unison.rb
@@ -135,6 +135,8 @@ module DockerSync
 
       # cares about conflict resolution
       def sync_prefer
+        sync_host_port = get_host_port(get_container_name, UNISON_CONTAINER_PORT)
+
         case @options.fetch('sync_prefer', 'default')
         when 'default' then "-prefer '#{@options['src']}' -copyonconflict" # thats our default, if nothing is set
         when 'src' then "-prefer '#{@options['src']}'"


### PR DESCRIPTION
When syncing using Unison and specifying `sync_prefer` as `dest` (line 142/143), the `sync_host_port` variable is not defined.

Fix is similar to how the `sync_host_port` was defined in line 126.

Tested and working locally.