### PR TITLE
Add default sync excludes (daemon.log & daemon.pid)

### DIFF
--- a/lib/docker-sync/environment.rb
+++ b/lib/docker-sync/environment.rb
@@ -21,5 +21,9 @@ module DockerSync
     def self.system(cmd)
       defined?(Bundler) ? Bundler.unbundled_system(cmd) : Kernel.system(cmd)
     end
+
+    def self.default_ignores()
+      ['.docker-sync/daemon.log', '.docker-sync/daemon.pid']
+    end
   end
 end

--- a/lib/docker-sync/sync_strategy/native_osx.rb
+++ b/lib/docker-sync/sync_strategy/native_osx.rb
@@ -183,7 +183,7 @@ module DockerSync
         end
 
         unless @options['sync_excludes'].nil?
-          expanded_ignore_strings = @options['sync_excludes'].map do |pattern|
+          expanded_ignore_strings = @options['sync_excludes'].append(Environment.default_ignores).flatten!.map do |pattern|
             if exclude_type == 'none'
               # the ignore type like Name / Path are part of the pattern
               ignore_string = "#{pattern}"

--- a/lib/docker-sync/sync_strategy/rsync.rb
+++ b/lib/docker-sync/sync_strategy/rsync.rb
@@ -61,8 +61,10 @@ module DockerSync
 
       def sync_options
         args = []
-        unless @options['sync_excludes'].nil?
-          args = @options['sync_excludes'].map { |pattern| "--exclude='#{pattern}'" } + args
+        excludes_list = @options['sync_excludes'].append(Environment.default_ignores).flatten!
+
+        unless excludes_list.nil?
+          args = excludes_list.map { |pattern| "--exclude='#{pattern}'" } + args
         end
         args.push('-ap')
         args.push(@options['sync_args']) if @options.key?('sync_args')

--- a/lib/docker-sync/sync_strategy/unison.rb
+++ b/lib/docker-sync/sync_strategy/unison.rb
@@ -102,7 +102,7 @@ module DockerSync
         exclude_type = @options['sync_excludes_type'] unless @options['sync_excludes_type'].nil?
 
         unless @options['sync_excludes'].nil?
-          expanded_ignore_strings = @options['sync_excludes'].map do |pattern|
+          expanded_ignore_strings = @options['sync_excludes'].append(Environment.default_ignores).flatten!.map do |pattern|
             ignore_string = if exclude_type == 'none'
                               # the ignore type like Name / Path are part of the pattern
                               pattern.to_s


### PR DESCRIPTION
Add daemon.log and daemon.pid to a default sync excludes directory.

`unison` strategy and `native_osx` strategy changes validated and tested.

**Help wanted to validate rsync strategy.**