### PR TITLE
Use the Unison 'Name' prefix for default ignores

### DIFF
--- a/lib/docker-sync/sync_strategy/unison.rb
+++ b/lib/docker-sync/sync_strategy/unison.rb
@@ -101,8 +101,16 @@ module DockerSync
         exclude_type = 'Name'
         exclude_type = @options['sync_excludes_type'] unless @options['sync_excludes_type'].nil?
 
+        # use the 'Name' exclude type for all default ignores
+        # to prevent conflicts with the sync_excludes_type settings
+        unless Environment.default_ignores.nil?
+          expanded_ignore_strings = Environment.default_ignores.map do |pattern|
+            "-ignore='Name #{pattern}'"
+          end
+        end
+
         unless @options['sync_excludes'].nil?
-          expanded_ignore_strings = @options['sync_excludes'].append(Environment.default_ignores).flatten!.map do |pattern|
+          expanded_ignore_strings = @options['sync_excludes'].map do |pattern|
             ignore_string = if exclude_type == 'none'
                               # the ignore type like Name / Path are part of the pattern
                               pattern.to_s


### PR DESCRIPTION
We cannot rely on `sync_excludes_type` for default ignores, at the user can and will override it for his needs.

Ref: https://github.com/EugenMayer/docker-sync/issues/819