### PR TITLE
Fix overriden default ignores

### DIFF
--- a/lib/docker-sync/sync_strategy/native_osx.rb
+++ b/lib/docker-sync/sync_strategy/native_osx.rb
@@ -176,6 +176,7 @@ module DockerSync
 
       def expand_ignore_strings
         expanded_ignore_strings = []
+        default_expanded_ignore_strings = []
 
         exclude_type = 'Name'
         unless @options['sync_excludes_type'].nil?
@@ -185,7 +186,7 @@ module DockerSync
         # use the 'Name' exclude type for all default ignores
         # to prevent conflicts with the sync_excludes_type settings
         unless Environment.default_ignores.nil?
-          expanded_ignore_strings = Environment.default_ignores.map do |pattern|
+          default_expanded_ignore_strings = Environment.default_ignores.map do |pattern|
             "-ignore='Name #{pattern}'"
           end
         end
@@ -201,7 +202,7 @@ module DockerSync
             "-ignore='#{ignore_string}'"
           end
         end
-        expanded_ignore_strings
+        expanded_ignore_strings.append(default_expanded_ignore_strings).flatten!
       end
     end
   end

--- a/lib/docker-sync/sync_strategy/unison.rb
+++ b/lib/docker-sync/sync_strategy/unison.rb
@@ -97,6 +97,7 @@ module DockerSync
 
       def expand_ignore_strings
         expanded_ignore_strings = []
+        default_expanded_ignore_strings = []
 
         exclude_type = 'Name'
         exclude_type = @options['sync_excludes_type'] unless @options['sync_excludes_type'].nil?
@@ -104,7 +105,7 @@ module DockerSync
         # use the 'Name' exclude type for all default ignores
         # to prevent conflicts with the sync_excludes_type settings
         unless Environment.default_ignores.nil?
-          expanded_ignore_strings = Environment.default_ignores.map do |pattern|
+          default_expanded_ignore_strings = Environment.default_ignores.map do |pattern|
             "-ignore='Name #{pattern}'"
           end
         end
@@ -120,7 +121,7 @@ module DockerSync
             "-ignore='#{ignore_string}'"
           end
         end
-        expanded_ignore_strings
+        expanded_ignore_strings.append(default_expanded_ignore_strings).flatten!
       end
 
       def sync_options


### PR DESCRIPTION
During the fix for the exclude type, the default ignores were being overridden by the excludes list.

Seperating them into two and appending + flattening them on returning.