### PR TITLE
Fix docker-sync strategy detection on newer versions of docker on mac

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    docker-sync (1.0.4)
+    docker-sync (1.0.5)
       daemons (~> 1.4, >= 1.4.1)
       dotenv (~> 2.8, >= 2.8.1)
       gem_update_checker (~> 0.2.0, >= 0.2.0)
@@ -57,6 +57,7 @@ GEM
 
 PLATFORMS
   aarch64-linux
+  arm64-darwin-21
   x86_64-darwin-17
   x86_64-linux
 

--- a/lib/docker-sync/config/project_config.rb
+++ b/lib/docker-sync/config/project_config.rb
@@ -144,7 +144,7 @@ module DockerSync
 
       def default_sync_strategy
         return 'native'     if Environment.linux?
-        return 'native_osx' if Environment.mac? && Dependencies::Docker::Driver.docker_for_mac?
+        return 'native_osx' if Environment.mac? && Dependencies::Docker::Driver.docker_on_mac?
         return 'unison'     if Environment.mac?
       end
 

--- a/lib/docker-sync/dependencies/docker_driver.rb
+++ b/lib/docker-sync/dependencies/docker_driver.rb
@@ -2,14 +2,11 @@ module DockerSync
   module Dependencies
     module Docker
       module Driver
-        def self.docker_for_mac?
+        def self.docker_on_mac?
           return false unless Environment.mac?
-          return @docker_for_mac if defined? @docker_for_mac
+          return @docker_on_mac if defined? @docker_on_mac
 
-          # com.docker.hyperkit for old virtualization engine
-          # com.docker.virtualization for new virtualization engine
-          # see https://docs.docker.com/desktop/mac/#enable-the-new-apple-virtualization-framework
-          @docker_for_mac = Environment.system('pgrep -q com.docker.hyperkit') || Environment.system('pgrep -q com.docker.virtualization')
+          @docker_on_mac = docker_desktop? || docker_for_mac?
         end
 
         def self.docker_toolbox?
@@ -17,6 +14,20 @@ module DockerSync
           return false unless find_executable0('docker-machine')
           return @docker_toolbox if defined? @docker_toolbox
           @docker_toolbox = Environment.system('docker info | grep -q "Operating System: Boot2Docker"')
+        end
+
+        private
+
+        def self.docker_for_mac?
+          # com.docker.hyperkit for old virtualization engine
+          # com.docker.virtualization for new virtualization engine
+          # see https://docs.docker.com/desktop/mac/#enable-the-new-apple-virtualization-framework
+          Environment.system('pgrep -q com.docker.hyperkit') || Environment.system('pgrep -q com.docker.virtualization')
+        end
+
+        def self.docker_desktop?
+          # detect if using docker desktop
+          Environment.system('docker info | grep -q "Operating System: Docker Desktop"')
         end
       end
     end


### PR DESCRIPTION
I was having issues trying to rely on the default strategy, I was getting `unison` when the expected was `native-osx` as I was running on mac.

Here are some scenarios I tested:

- When using the latest docker desktop (4.17.0), without Virtualization Framework activated, the default strategy fall back to `unison`

  I tested the commands `pgrep -q com.docker.hyperkit` and `pgrep -q com.docker.virtualization` and both return `exit 1`

- When enabling the Virtualization Frameware, the `pgrep -q com.docker.virtualization` command returns `exit 0` and the default strategy was correct (`native-osx`)

- I also tested on Docker Desktop 4.2 with the same results.

I figure that maybe we want to detect whether we are using Docker Desktop on a mac, and then fallback to detect the virtualization processes.

Any feedback is welcome on the changes proposed