### PR TITLE
add sync_host option and resolve ip address.

### DIFF
--- a/lib/docker-sync/sync_process.rb
+++ b/lib/docker-sync/sync_process.rb
@@ -28,6 +28,11 @@ module DockerSync
           'verbose' => false,
       }
 
+      # resolve ip address if sync_host set
+      if options.key?('sync_host') && options['sync_host'].to_s != ''
+        options['sync_host_ip']= IPSocket.getaddress(options['sync_host'])
+      end
+
       # even if sync_host_ip is set, if it is set to auto, enforce the default
       if !options.key?('sync_host_ip') || options['sync_host_ip'] == 'auto' || options['sync_host_ip'] == ''
         options['sync_host_ip'] = get_host_ip_default


### PR DESCRIPTION
I came across this great solution when I was having trouble syncing files when using remote docker. Thanks.

How about adding the sync_host option to specify the sync host by domain name?