### PR TITLE
fix(docker-compose): compatibility with docker-compose v2 and docker >= v27

### DIFF
--- a/lib/docker-sync/docker_compose_session.rb
+++ b/lib/docker-sync/docker_compose_session.rb
@@ -43,7 +43,7 @@ module DockerSync
         command_args = ['compose'] + file_args + args
       end
 
-      @last_command = Command.run(command, *docker_args, dir: @dir).join
+      @last_command = Command.run(command, *command_args, dir: @dir).join
       status = @last_command.status
       out = @last_command.captured_output
       err = @last_command.captured_error

--- a/lib/docker-sync/docker_compose_session.rb
+++ b/lib/docker-sync/docker_compose_session.rb
@@ -26,14 +26,24 @@ module DockerSync
 
     private
 
+    def docker_compose_binary_exists?
+      system('which docker-compose > /dev/null 2>&1')
+    end
+
+
     def run!(*args)
       # file_args and args should be Array of String
       file_args = @files.map { |file| "--file=#{file}" }
 
-      # Prepend "compose" to the args array
-      docker_args = ["compose", *file_args, *args]
+      if docker_compose_binary_exists?
+        command = 'docker-compose'
+        command_args = file_args + args
+      else
+        command = 'docker'
+        command_args = ['compose'] + file_args + args
+      end
 
-      @last_command = Command.run('docker', *docker_args, dir: @dir).join
+      @last_command = Command.run(command, *docker_args, dir: @dir).join
       status = @last_command.status
       out = @last_command.captured_output
       err = @last_command.captured_error

--- a/lib/docker-sync/docker_compose_session.rb
+++ b/lib/docker-sync/docker_compose_session.rb
@@ -30,7 +30,10 @@ module DockerSync
       # file_args and args should be Array of String
       file_args = @files.map { |file| "--file=#{file}" }
 
-      @last_command = Command.run('docker-compose', *file_args, *args, dir: @dir).join
+      # Prepend "compose" to the args array
+      docker_args = ["compose", *file_args, *args]
+
+      @last_command = Command.run('docker', *docker_args, dir: @dir).join
       status = @last_command.status
       out = @last_command.captured_output
       err = @last_command.captured_error

--- a/lib/docker-sync/docker_compose_session.rb
+++ b/lib/docker-sync/docker_compose_session.rb
@@ -26,7 +26,7 @@ module DockerSync
 
     private
 
-    def docker_compose_binary_exists?
+    def docker_compose_legacy_binary_exists?
       system('which docker-compose > /dev/null 2>&1')
     end
 
@@ -35,7 +35,7 @@ module DockerSync
       # file_args and args should be Array of String
       file_args = @files.map { |file| "--file=#{file}" }
 
-      if docker_compose_binary_exists?
+      if docker_compose_legacy_binary_exists?
         command = 'docker-compose'
         command_args = file_args + args
       else


### PR DESCRIPTION
As the docker-compose binary was removed and replaced by calling `docker compose` within the `docker` binary as docker-compose v2, we need to update how we call the compose commands here.

See https://docs.docker.com/compose/migrate/