### PR TITLE
Fix typo in documentation

### DIFF
--- a/docs/getting-started/configuration.rst
+++ b/docs/getting-started/configuration.rst
@@ -244,7 +244,7 @@ Options                       Description
 IP address                    If you set this to a concrete IP, this OP will be enforced
 ==========================    ===============
 
-sync_prefe
+sync_prefer
 ^^^^^^^^^^^
 Type:
   optional


### PR DESCRIPTION
Fix for https://github.com/EugenMayer/docker-sync/issues/844